### PR TITLE
Keep force-terminated runs CANCELED when steps finish after the force-mark

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/api.py
+++ b/python_modules/dagster/dagster/_core/execution/api.py
@@ -805,6 +805,14 @@ def job_execution_iterator(
                     error_info=job_exception_info,
                     message="Run failed after it was requested to be terminated.",
                 )
+            elif reloaded_run and reloaded_run.status == DagsterRunStatus.CANCELED:
+                # This happens if the run was force-terminated but an exception was thrown
+                # during execution before the worker exited
+                event = DagsterEvent.engine_event(
+                    job_context,
+                    "Run failed with an exception after the run was forcibly marked as canceled.",
+                    EngineEventData(),
+                )
             else:
                 event = DagsterEvent.job_failure(
                     job_context,
@@ -822,6 +830,15 @@ def job_execution_iterator(
                     error_info=None,
                     message=f"Run was canceled. Failed steps: {failed_step_keys}.",
                 )
+            elif reloaded_run and reloaded_run.status == DagsterRunStatus.CANCELED:
+                # This happens if the run was force-terminated but the steps were still
+                # executing and failed before the worker exited
+                event = DagsterEvent.engine_event(
+                    job_context,
+                    "Steps failed after the run was forcibly marked as canceled. Failed steps:"
+                    f" {failed_step_keys}.",
+                    EngineEventData(),
+                )
             else:
                 event = DagsterEvent.job_failure(
                     job_context,
@@ -830,7 +847,18 @@ def job_execution_iterator(
                     first_step_failure_event=failed_steps[0],
                 )
         else:
-            event = DagsterEvent.job_success(job_context)
+            reloaded_run = job_context.instance.get_run_by_id(job_context.run_id)
+            if reloaded_run and reloaded_run.status == DagsterRunStatus.CANCELED:
+                # This happens if the run was force-terminated but the steps finished executing
+                # successfully before the worker exited
+                event = DagsterEvent.engine_event(
+                    job_context,
+                    "Execution of steps finished successfully after the run was forcibly marked"
+                    " as canceled.",
+                    EngineEventData(),
+                )
+            else:
+                event = DagsterEvent.job_success(job_context)
         if not generator_closed:
             yield event
 

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
@@ -657,6 +657,62 @@ def test_cleanup_after_force_terminate(
     assert run and run.status == DagsterRunStatus.CANCELED
 
 
+def test_run_remains_canceled_when_steps_finish_after_force_terminate(
+    instance: DagsterInstance,
+    workspace: WorkspaceRequestContext,
+):
+    # Simulates force-termination (MARK_AS_CANCELED_IMMEDIATELY) where the cancellation
+    # request never reaches the run worker: the run is marked CANCELED while the worker
+    # is mid-step, the step then finishes successfully, and the run should stay CANCELED
+    # instead of flipping to SUCCESS (#34175).
+    remote_job = workspace.get_code_location("test").get_repository("nope").get_full_job("slow_job")
+    run = instance.create_run_for_job(
+        job_def=slow_job,
+        remote_job_origin=remote_job.get_remote_origin(),
+        job_code_origin=remote_job.get_python_origin(),
+    )
+
+    run_id = run.run_id
+
+    instance.launch_run(run.run_id, workspace)
+
+    poll_for_step_start(instance, run_id, message="slow_sudop")
+
+    # simulate the run being marked as canceled while the worker is still executing,
+    # without the termination request reaching the worker
+    instance.report_run_canceling(run)
+    instance.report_run_canceled(run)
+
+    # wait for the run worker to finish executing the step and exit
+    poll_for_event(
+        instance,
+        run_id,
+        event_type="ENGINE_EVENT",
+        message="Process for run exited",
+    )
+
+    logs = instance.all_logs(run_id)
+    _check_event_log_contains(
+        logs,
+        [
+            ("STEP_SUCCESS", 'Finished execution of step "slow_sudop"'),
+            (
+                "ENGINE_EVENT",
+                "Execution of steps finished successfully after the run was forcibly marked"
+                " as canceled.",
+            ),
+        ],
+    )
+    assert not any(
+        event.is_dagster_event
+        and event.get_dagster_event().event_type == DagsterEventType.PIPELINE_SUCCESS
+        for event in logs
+    )
+
+    run = instance.get_run_by_id(run_id)
+    assert run and run.status == DagsterRunStatus.CANCELED
+
+
 def _get_engine_events(event_records):
     return [
         er


### PR DESCRIPTION
## Summary & Motivation

Fixes #34175.

A run force-terminated with `MARK_AS_CANCELED_IMMEDIATELY` is marked CANCELED while its run worker keeps executing (as documented: the force path marks the run canceled without stopping the worker). When the worker's steps later finish, `job_execution_iterator` unconditionally emitted `PIPELINE_SUCCESS` (or `PIPELINE_FAILURE` on an exception or failed steps), so the run moved from CANCELED to SUCCESS (or FAILURE) and run-status sensors fired on the new status. A run an operator force-cancelled could report success minutes later.

The interrupt path in `job_execution_iterator` already handled the analogous case (#5985) by re-reading the run status before emitting its terminal event. This applies the same re-read to the success, exception, and failed-steps paths: when the run is already CANCELED, emit an engine event recording the late worker completion instead of a terminal run event, so the run stays CANCELED.

Step-level events (`STEP_SUCCESS` etc.) are still recorded: the worker's work is not lost from the log; only the run-level terminal status no longer overwrites the cancellation.

## Test Plan

Added `test_run_remains_canceled_when_steps_finish_after_force_terminate` in `launcher_tests/test_default_run_launcher.py`, mirroring the existing `test_cleanup_after_force_terminate` but letting the step finish successfully after the force-mark instead of interrupting the worker. It asserts the step success event lands, no `PIPELINE_SUCCESS` is emitted, and the run status stays CANCELED.

Verified locally (Python 3.13):

- `pytest dagster_tests/launcher_tests/test_default_run_launcher.py`: 23 passed (the new test fails on unpatched `master` with `RUN_SUCCESS` overwriting the CANCELED status, passes with this change)
- `pytest dagster_tests/execution_tests/misc_execution_tests/test_api_iterators.py dagster_tests/execution_tests/misc_execution_tests/test_run_cancellation_thread.py`: 10 passed
- `pytest dagster_tests/execution_tests/misc_execution_tests/test_interrupt.py`: 9 passed
- `pytest dagster_graphql_tests/graphql/test_run_cancellation.py` (dagster-graphql): 15 passed
- `ruff check` / `ruff format --check` clean on both changed files

## How I Tested These Changes

Same as the Test Plan: ran the launcher, execution, and graphql cancellation suites locally against the patch and confirmed the new regression test fails on unpatched master and passes with the fix.
