### PR TITLE
fix(dg): preserve .env formatting in plus pull env

### DIFF
--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/env.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/env.py
@@ -92,15 +92,21 @@ class ProjectEnvVars:
 
             lines = []
             existing_keys = set()
-            with env_path.open(encoding="utf-8") as env_file:
+            with env_path.open(encoding="utf-8", newline="") as env_file:
                 for binding in parse_stream(env_file):
                     if binding.key is None:
                         lines.append(binding.original.string)
                     elif binding.key in values_to_write:
                         original = binding.original.string
-                        key_index = original.rfind(binding.key)
+                        key_index = original.find(binding.key)
                         prefix = original[:key_index] if key_index >= 0 else ""
-                        line_ending = "\n" if original.endswith("\n") else ""
+                        line_ending = (
+                            "\r\n"
+                            if original.endswith("\r\n")
+                            else "\n"
+                            if original.endswith("\n")
+                            else ""
+                        )
                         lines.append(
                             f"{prefix}{binding.key}={values_to_write[binding.key]}{line_ending}"
                         )
@@ -108,11 +114,19 @@ class ProjectEnvVars:
 
             for key, value in values_to_write.items():
                 if key not in existing_keys:
-                    if lines and not lines[-1].endswith("\n"):
+                    append_line_ending = (
+                        "\r\n"
+                        if lines and lines[-1].endswith("\r\n")
+                        else "\n"
+                        if lines and lines[-1].endswith("\n")
+                        else ""
+                    )
+                    if lines and append_line_ending == "":
                         lines.append("\n")
-                    lines.append(f"{key}={value}")
+                    lines.append(f"{key}={value}{append_line_ending}")
 
-            env_path.write_text("".join(lines), encoding="utf-8")
+            with env_path.open("w", encoding="utf-8", newline="") as env_file:
+                env_file.write("".join(lines))
         else:
             env_path.write_text(
                 "\n".join([f"{key}={value}" for key, value in values_to_write.items()])

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core/env.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core/env.py
@@ -85,6 +85,35 @@ class ProjectEnvVars:
 
     def write(self) -> None:
         env_path = self.ctx.root_path / ".env"
-        env_path.write_text(
-            "\n".join([f"{key}={value}" for key, value in self.values.items() if value is not None])
-        )
+        values_to_write = {key: value for key, value in self.values.items() if value is not None}
+
+        if env_path.exists():
+            from dotenv.parser import parse_stream
+
+            lines = []
+            existing_keys = set()
+            with env_path.open(encoding="utf-8") as env_file:
+                for binding in parse_stream(env_file):
+                    if binding.key is None:
+                        lines.append(binding.original.string)
+                    elif binding.key in values_to_write:
+                        original = binding.original.string
+                        key_index = original.rfind(binding.key)
+                        prefix = original[:key_index] if key_index >= 0 else ""
+                        line_ending = "\n" if original.endswith("\n") else ""
+                        lines.append(
+                            f"{prefix}{binding.key}={values_to_write[binding.key]}{line_ending}"
+                        )
+                        existing_keys.add(binding.key)
+
+            for key, value in values_to_write.items():
+                if key not in existing_keys:
+                    if lines and not lines[-1].endswith("\n"):
+                        lines.append("\n")
+                    lines.append(f"{key}={value}")
+
+            env_path.write_text("".join(lines), encoding="utf-8")
+        else:
+            env_path.write_text(
+                "\n".join([f"{key}={value}" for key, value in values_to_write.items()])
+            )

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core_tests/test_env.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core_tests/test_env.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from dagster_dg_core.env import ProjectEnvVars
+
+
+def test_write_preserves_existing_dotenv_formatting(tmp_path: Path) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "\n".join(
+            [
+                "DAGSTER_HOME=/Users/king/.dagster/homes/example",
+                "",
+                "AWS_REGION=us-west-2",
+                "AWS_PRIMARY_AVAILABILITY_ZONE_ID=usw2-az1",
+                "",
+                "SOURCE__SNOWFLAKE__HOST=somehost",
+                "SOURCE__SNOWFLAKE__USERNAME=someuser",
+                "SOURCE__SNOWFLAKE__PASSWORD=oldpassword",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    ctx = SimpleNamespace(is_project=True, root_path=tmp_path)
+
+    ProjectEnvVars.from_ctx(ctx).with_values(
+        {
+            "AWS_REGION": "us-east-1",
+            "SOURCE__SNOWFLAKE__PASSWORD": "somepassword",
+            "NEW_SECRET": "newvalue",
+        }
+    ).write()
+
+    assert env_path.read_text(encoding="utf-8") == "\n".join(
+        [
+            "DAGSTER_HOME=/Users/king/.dagster/homes/example",
+            "",
+            "AWS_REGION=us-east-1",
+            "AWS_PRIMARY_AVAILABILITY_ZONE_ID=usw2-az1",
+            "",
+            "SOURCE__SNOWFLAKE__HOST=somehost",
+            "SOURCE__SNOWFLAKE__USERNAME=someuser",
+            "SOURCE__SNOWFLAKE__PASSWORD=somepassword",
+            "NEW_SECRET=newvalue",
+        ]
+    )

--- a/python_modules/libraries/dagster-dg-core/dagster_dg_core_tests/test_env.py
+++ b/python_modules/libraries/dagster-dg-core/dagster_dg_core_tests/test_env.py
@@ -45,3 +45,25 @@ def test_write_preserves_existing_dotenv_formatting(tmp_path: Path) -> None:
             "NEW_SECRET=newvalue",
         ]
     )
+
+
+def test_write_updates_assignment_when_key_also_appears_later_in_line(tmp_path: Path) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text("API_TOKEN=old # API_TOKEN\n", encoding="utf-8")
+
+    ctx = SimpleNamespace(is_project=True, root_path=tmp_path)
+
+    ProjectEnvVars.from_ctx(ctx).with_values({"API_TOKEN": "new"}).write()
+
+    assert env_path.read_text(encoding="utf-8") == "API_TOKEN=new\n"
+
+
+def test_write_preserves_crlf_when_appending_to_dotenv(tmp_path: Path) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_bytes(b"API_TOKEN=old\r\n\r\nOTHER=value\r\n")
+
+    ctx = SimpleNamespace(is_project=True, root_path=tmp_path)
+
+    ProjectEnvVars.from_ctx(ctx).with_values({"API_TOKEN": "new", "NEW_SECRET": "newvalue"}).write()
+
+    assert env_path.read_bytes() == b"API_TOKEN=new\r\n\r\nOTHER=value\r\nNEW_SECRET=newvalue\r\n"


### PR DESCRIPTION
## Summary & Motivation

Fixes #33768.

`dg plus pull env` previously preserved existing `.env` values, but rewrote the file from parsed key-value pairs. This dropped blank lines and changed user-maintained ordering.

This updates `.env` writing so existing variables are updated in place, blank lines/order are preserved, and newly pulled variables are appended.

## Test Plan

- `python -m pytest python_modules/libraries/dagster-dg-core/dagster_dg_core_tests/test_env.py -q`
- `python -m pytest python_modules/libraries/dagster-dg-cli/dagster_dg_cli_tests/cli_tests/plus_tests/test_plus_env_command.py -q`
- `ruff check python_modules/libraries/dagster-dg-core/dagster_dg_core/env.py python_modules/libraries/dagster-dg-core/dagster_dg_core_tests/test_env.py`
- `ruff format --check python_modules/libraries/dagster-dg-core/dagster_dg_core/env.py python_modules/libraries/dagster-dg-core/dagster_dg_core_tests/test_env.py`