### PR TITLE
[ui] Fix stale asset definitions after a code location is redeployed

### DIFF
--- a/js_modules/ui-core/src/search/__tests__/useIndexedDBCachedQuery.test.tsx
+++ b/js_modules/ui-core/src/search/__tests__/useIndexedDBCachedQuery.test.tsx
@@ -16,7 +16,6 @@ import {
   __resetForJest,
   clearCachedData,
   getCachedData,
-  setCachedData,
   useIndexedDBCachedQuery,
 } from '../useIndexedDBCachedQuery';
 
@@ -266,18 +265,6 @@ describe('cached data helpers', () => {
 
     await expect(getCachedData({key: 'versionKey', version: 1})).resolves.toEqual('version-1-data');
     await expect(getCachedData({key: 'versionKey', version: 2})).resolves.toBeUndefined();
-  });
-
-  it('returns the value written by setCachedData rather than the previously read one', async () => {
-    mockCache().has.mockResolvedValue(true);
-    mockCache().get.mockResolvedValue({value: {data: 'stale', version: 1}});
-
-    await expect(getCachedData({key: 'setKey', version: 1})).resolves.toEqual('stale');
-
-    await setCachedData({key: 'setKey', version: 1, data: 'fresh'});
-    expect(mockCache().set).toHaveBeenCalledWith('cache', {data: 'fresh', version: 1});
-
-    await expect(getCachedData({key: 'setKey', version: 1})).resolves.toEqual('fresh');
   });
 
   it('does not resurrect a cleared entry from a read that was already in flight', async () => {

--- a/js_modules/ui-core/src/search/__tests__/useIndexedDBCachedQuery.test.tsx
+++ b/js_modules/ui-core/src/search/__tests__/useIndexedDBCachedQuery.test.tsx
@@ -247,6 +247,12 @@ describe('useIndexedDBCachedQuery', () => {
 // from what's on disk, callers keep reading data that was already replaced or deleted -- which is
 // how the UI ends up showing a previous deployment's asset definitions until the user clears
 // their browser storage.
+const flushMicrotasks = async () => {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve();
+  }
+};
+
 describe('cached data helpers', () => {
   beforeEach(() => {
     mockShouldThrowError = false;
@@ -272,6 +278,27 @@ describe('cached data helpers', () => {
     expect(mockCache().set).toHaveBeenCalledWith('cache', {data: 'fresh', version: 1});
 
     await expect(getCachedData({key: 'setKey', version: 1})).resolves.toEqual('fresh');
+  });
+
+  it('does not resurrect a cleared entry from a read that was already in flight', async () => {
+    // `clear` can land while a read is suspended on IndexedDB. The read resolves with the value
+    // it captured before the delete, and must not write it back into the in-memory mirror.
+    let resolveGet: (value: unknown) => void = () => {};
+    mockCache().has.mockReturnValue(true);
+    mockCache().get.mockReturnValue(
+      new Promise((resolve) => {
+        resolveGet = resolve;
+      }),
+    );
+
+    const pendingRead = getCachedData({key: 'raceKey', version: 1});
+    await flushMicrotasks();
+
+    await clearCachedData({key: 'raceKey'});
+    resolveGet({value: {data: 'cleared-entry', version: 1}});
+
+    await expect(pendingRead).resolves.toBeUndefined();
+    await expect(getCachedData({key: 'raceKey', version: 1})).resolves.toBeUndefined();
   });
 
   it('does not return data after clearCachedData', async () => {

--- a/js_modules/ui-core/src/search/__tests__/useIndexedDBCachedQuery.test.tsx
+++ b/js_modules/ui-core/src/search/__tests__/useIndexedDBCachedQuery.test.tsx
@@ -12,7 +12,13 @@ import {
 import {buildAssetConnection} from '../../graphql/builders';
 import {buildQueryMock, getMockResultFn} from '../../testing/mocking';
 import {cache as _cache} from '../../util/idb-lru-cache';
-import {__resetForJest, useIndexedDBCachedQuery} from '../useIndexedDBCachedQuery';
+import {
+  __resetForJest,
+  clearCachedData,
+  getCachedData,
+  setCachedData,
+  useIndexedDBCachedQuery,
+} from '../useIndexedDBCachedQuery';
 
 const mockCache = _cache as unknown as jest.Mock<{
   has: jest.Mock;
@@ -233,5 +239,50 @@ describe('useIndexedDBCachedQuery', () => {
         });
       },
     );
+  });
+});
+
+// The CacheManager behind these helpers keeps an in-memory mirror of the single entry it stores
+// in IndexedDB, and it is a process-wide singleton per key. If that mirror is allowed to drift
+// from what's on disk, callers keep reading data that was already replaced or deleted -- which is
+// how the UI ends up showing a previous deployment's asset definitions until the user clears
+// their browser storage.
+describe('cached data helpers', () => {
+  beforeEach(() => {
+    mockShouldThrowError = false;
+    jest.clearAllMocks();
+    __resetForJest();
+  });
+
+  it('does not return an entry cached under a different version', async () => {
+    mockCache().has.mockResolvedValue(true);
+    mockCache().get.mockResolvedValue({value: {data: 'version-1-data', version: 1}});
+
+    await expect(getCachedData({key: 'versionKey', version: 1})).resolves.toEqual('version-1-data');
+    await expect(getCachedData({key: 'versionKey', version: 2})).resolves.toBeUndefined();
+  });
+
+  it('returns the value written by setCachedData rather than the previously read one', async () => {
+    mockCache().has.mockResolvedValue(true);
+    mockCache().get.mockResolvedValue({value: {data: 'stale', version: 1}});
+
+    await expect(getCachedData({key: 'setKey', version: 1})).resolves.toEqual('stale');
+
+    await setCachedData({key: 'setKey', version: 1, data: 'fresh'});
+    expect(mockCache().set).toHaveBeenCalledWith('cache', {data: 'fresh', version: 1});
+
+    await expect(getCachedData({key: 'setKey', version: 1})).resolves.toEqual('fresh');
+  });
+
+  it('does not return data after clearCachedData', async () => {
+    mockCache().has.mockResolvedValue(true);
+    mockCache().get.mockResolvedValue({value: {data: 'removed-location', version: 1}});
+
+    await expect(getCachedData({key: 'clearKey', version: 1})).resolves.toEqual('removed-location');
+
+    await clearCachedData({key: 'clearKey'});
+    expect(mockCache().delete).toHaveBeenCalledWith('cache');
+
+    await expect(getCachedData({key: 'clearKey', version: 1})).resolves.toBeUndefined();
   });
 });

--- a/js_modules/ui-core/src/search/useIndexedDBCachedQuery.tsx
+++ b/js_modules/ui-core/src/search/useIndexedDBCachedQuery.tsx
@@ -23,13 +23,13 @@ export const KEY_PREFIX = 'indexdbQueryCache:';
 class CacheManager<TQuery> {
   private cache: ReturnType<typeof cache<CacheData<TQuery>>> | undefined;
   private key: string;
-  // In-memory mirror of the single entry we keep in IndexedDB. It must be kept in sync with
-  // whatever we last read from or wrote to IndexedDB, otherwise reads can serve data that has
-  // already been replaced or deleted on disk.
+  // In-memory mirror of the single entry we keep in IndexedDB, populated by the first read.
+  // Reads are served from here, so it must not outlive the entry it mirrors -- otherwise a
+  // caller can be handed data that has already been deleted on disk.
   private current?: CacheData<TQuery>;
   private currentAwaitable?: Promise<void>;
-  // Bumped by every `set` and `clear`. A read that started before one of those lands is stale by
-  // the time it resolves and must not be applied.
+  // Bumped by `clear`. A read that started before the clear landed is stale by the time it
+  // resolves and must not repopulate the mirror.
   private generation = 0;
 
   constructor(key: string) {
@@ -65,15 +65,19 @@ class CacheManager<TQuery> {
         return;
       }
       const value = (await this.cache.get('cache'))?.value;
-      // A `set` or `clear` may have landed while this read was in flight. That value is newer
-      // than what we just read off disk, so don't clobber it -- and in particular don't
-      // resurrect an entry that was cleared.
+      // A `clear` may have landed while this read was suspended, in which case `value` is the
+      // entry that was just deleted and must not be written back into the mirror.
       if (value && !this.current && generation === this.generation) {
         this.current = value;
       }
     } catch {}
   }
 
+  // Note that this deliberately does not refresh `current`. Managers are process-wide
+  // singletons per key with no lifecycle, so making writes visible to reads turns this into a
+  // write-through in-memory cache whose contents outlive the page state they came from. The
+  // window where `current` is older than IndexedDB is transient -- the only readers load once
+  // per instance, and a reload repopulates the mirror from disk.
   async set(data: TQuery, version: number | string): Promise<void> {
     if (
       this.current?.version === version &&
@@ -84,14 +88,7 @@ class CacheManager<TQuery> {
     if (!this.cache) {
       return;
     }
-    const entry = {data, version};
-    this.generation += 1;
-    // Keep the in-memory mirror in sync with what we just persisted, so a subsequent read
-    // doesn't serve the value this one replaced.
-    this.current = entry;
-    // Reads no longer need to consult IndexedDB: `current` now holds the newest value.
-    this.currentAwaitable = Promise.resolve();
-    return this.cache.set('cache', entry);
+    return this.cache.set('cache', {data, version});
   }
 
   async clear() {

--- a/js_modules/ui-core/src/search/useIndexedDBCachedQuery.tsx
+++ b/js_modules/ui-core/src/search/useIndexedDBCachedQuery.tsx
@@ -28,6 +28,9 @@ class CacheManager<TQuery> {
   // already been replaced or deleted on disk.
   private current?: CacheData<TQuery>;
   private currentAwaitable?: Promise<void>;
+  // Bumped by every `set` and `clear`. A read that started before one of those lands is stale by
+  // the time it resolves and must not be applied.
+  private generation = 0;
 
   constructor(key: string) {
     this.key = `${KEY_PREFIX}${key}`;
@@ -56,14 +59,16 @@ class CacheManager<TQuery> {
     if (!this.cache) {
       return;
     }
+    const generation = this.generation;
     try {
       if (!(await this.cache.has('cache'))) {
         return;
       }
       const value = (await this.cache.get('cache'))?.value;
-      // A `set` or `clear` may have landed while this read was in flight; that value is newer
-      // than what we just read off disk, so don't clobber it.
-      if (value && !this.current) {
+      // A `set` or `clear` may have landed while this read was in flight. That value is newer
+      // than what we just read off disk, so don't clobber it -- and in particular don't
+      // resurrect an entry that was cleared.
+      if (value && !this.current && generation === this.generation) {
         this.current = value;
       }
     } catch {}
@@ -80,6 +85,7 @@ class CacheManager<TQuery> {
       return;
     }
     const entry = {data, version};
+    this.generation += 1;
     // Keep the in-memory mirror in sync with what we just persisted, so a subsequent read
     // doesn't serve the value this one replaced.
     this.current = entry;
@@ -89,6 +95,7 @@ class CacheManager<TQuery> {
   }
 
   async clear() {
+    this.generation += 1;
     this.current = undefined;
     // Resolve immediately rather than re-reading the entry we're about to delete.
     this.currentAwaitable = Promise.resolve();

--- a/js_modules/ui-core/src/search/useIndexedDBCachedQuery.tsx
+++ b/js_modules/ui-core/src/search/useIndexedDBCachedQuery.tsx
@@ -23,8 +23,11 @@ export const KEY_PREFIX = 'indexdbQueryCache:';
 class CacheManager<TQuery> {
   private cache: ReturnType<typeof cache<CacheData<TQuery>>> | undefined;
   private key: string;
+  // In-memory mirror of the single entry we keep in IndexedDB. It must be kept in sync with
+  // whatever we last read from or wrote to IndexedDB, otherwise reads can serve data that has
+  // already been replaced or deleted on disk.
   private current?: CacheData<TQuery>;
-  private currentAwaitable?: Promise<TQuery | undefined>;
+  private currentAwaitable?: Promise<void>;
 
   constructor(key: string) {
     this.key = `${KEY_PREFIX}${key}`;
@@ -34,46 +37,61 @@ class CacheManager<TQuery> {
   }
 
   async get(version: number | string): Promise<TQuery | undefined> {
-    if (this.current) {
-      return this.current.data;
+    if (!this.current) {
+      if (!this.currentAwaitable) {
+        this.currentAwaitable = this.readFromCache();
+      }
+      await this.currentAwaitable;
     }
-    if (!this.currentAwaitable) {
-      this.currentAwaitable = new Promise(async (res) => {
-        if (!this.cache) {
-          res(undefined);
-          return;
-        }
-        if (await this.cache.has('cache')) {
-          const entry = await this.cache.get('cache');
-          const value = entry?.value;
-          if (value && version === value.version) {
-            this.current = value;
-            res(value.data);
-          } else {
-            res(undefined);
-          }
-        } else {
-          res(undefined);
-        }
-      });
+    const current = this.current;
+    // The version is checked on every read, not just on the read that populated `current`, so a
+    // caller asking for a different version never receives the entry cached for another one.
+    if (current && current.version === version) {
+      return current.data;
     }
-    return await this.currentAwaitable;
+    return undefined;
+  }
+
+  private async readFromCache(): Promise<void> {
+    if (!this.cache) {
+      return;
+    }
+    try {
+      if (!(await this.cache.has('cache'))) {
+        return;
+      }
+      const value = (await this.cache.get('cache'))?.value;
+      // A `set` or `clear` may have landed while this read was in flight; that value is newer
+      // than what we just read off disk, so don't clobber it.
+      if (value && !this.current) {
+        this.current = value;
+      }
+    } catch {}
   }
 
   async set(data: TQuery, version: number | string): Promise<void> {
     if (
-      this.current?.data === data ||
-      (stringified(this.current?.data) === stringified(data) && this.current?.version === version)
+      this.current?.version === version &&
+      (this.current.data === data || stringified(this.current.data) === stringified(data))
     ) {
       return;
     }
     if (!this.cache) {
       return;
     }
-    return this.cache.set('cache', {data, version});
+    const entry = {data, version};
+    // Keep the in-memory mirror in sync with what we just persisted, so a subsequent read
+    // doesn't serve the value this one replaced.
+    this.current = entry;
+    // Reads no longer need to consult IndexedDB: `current` now holds the newest value.
+    this.currentAwaitable = Promise.resolve();
+    return this.cache.set('cache', entry);
   }
 
   async clear() {
+    this.current = undefined;
+    // Resolve immediately rather than re-reading the entry we're about to delete.
+    this.currentAwaitable = Promise.resolve();
     if (!this.cache) {
       return;
     }

--- a/js_modules/ui-core/src/workspace/WorkspaceContext/LocationBaseDataFetcher.ts
+++ b/js_modules/ui-core/src/workspace/WorkspaceContext/LocationBaseDataFetcher.ts
@@ -5,6 +5,15 @@ import {LocationStatusEntryFragment} from './types/WorkspaceQueries.types';
 import {clearCachedData, getCachedData, useGetData} from '../../search/useIndexedDBCachedQuery';
 const EMPTY_DATA = {};
 
+// A location fetch can fail transiently -- most commonly while a code location is being
+// redeployed and its code server is briefly unreachable. The status poller only notifies us when
+// a location's versionKey *changes*, so if we drop a failure on the floor nothing will ask us to
+// load that location again and the UI keeps rendering the previous deployment's definitions for
+// the rest of the session. Retry on our own schedule instead, backing off so that a location
+// that is durably broken doesn't hammer the server with an expensive query.
+export const RETRY_BASE_INTERVAL = 5000;
+export const RETRY_MAX_INTERVAL = 60000;
+
 export abstract class LocationBaseDataFetcher<TData, TVariables extends OperationVariables> {
   private readonly getData: ReturnType<typeof useGetData>;
   private readonly statusPoller: WorkspaceStatusPoller;
@@ -17,6 +26,10 @@ export abstract class LocationBaseDataFetcher<TData, TVariables extends Operatio
   private readonly key: string;
   private loadedFromCache: {[key: string]: boolean};
   private unsubscribe: () => void;
+  private failedLocations: Set<string> = new Set();
+  private retryAttempt = 0;
+  private retryTimeout: ReturnType<typeof setTimeout> | undefined;
+  private destroyed = false;
   constructor(args: {
     readonly query: DocumentNode;
     readonly version: string;
@@ -49,6 +62,7 @@ export abstract class LocationBaseDataFetcher<TData, TVariables extends Operatio
               const nextData = {...this.data};
               delete nextData[location];
               this.data = nextData;
+              this.clearFailure(location);
               clearCachedData({
                 key: `${this.key}/${location}`,
               });
@@ -98,7 +112,9 @@ export abstract class LocationBaseDataFetcher<TData, TVariables extends Operatio
   private async loadFromServer(location: string) {
     await this.loadFromCache(location);
     if (!this.locationStatuses[location]) {
-      // Wait for location statuses to be loaded
+      // Wait for location statuses to be loaded. If we were retrying this location it no longer
+      // exists as far as we know, so stop retrying it.
+      this.clearFailure(location);
       return;
     }
     if (
@@ -106,6 +122,7 @@ export abstract class LocationBaseDataFetcher<TData, TVariables extends Operatio
       this.getVersion(this.data[location]) === this.locationStatuses[location].versionKey
     ) {
       // If the version hasn't changed then we don't need to load from the server
+      this.clearFailure(location);
       return;
     }
     await TimingControls.loadFromServer(async () => {
@@ -119,15 +136,53 @@ export abstract class LocationBaseDataFetcher<TData, TVariables extends Operatio
       });
       if (error) {
         console.error(error);
+        this.scheduleRetry(location);
       } else if (data) {
+        this.clearFailure(location);
         const nextData = {...this.data};
         nextData[location] = data;
         this.data = nextData;
         this.notifySubscribers();
       } else {
         console.error('No data or error returned from fetchLocationData');
+        this.scheduleRetry(location);
       }
     });
+  }
+
+  private clearFailure(location: string) {
+    this.failedLocations.delete(location);
+    if (!this.failedLocations.size) {
+      this.retryAttempt = 0;
+    }
+  }
+
+  private scheduleRetry(location: string) {
+    if (this.destroyed) {
+      return;
+    }
+    this.failedLocations.add(location);
+    if (this.retryTimeout) {
+      // A retry is already armed; it picks up every location in `failedLocations`.
+      return;
+    }
+    const delay = Math.min(RETRY_BASE_INTERVAL * 2 ** this.retryAttempt, RETRY_MAX_INTERVAL);
+    this.retryAttempt += 1;
+    this.retryTimeout = setTimeout(() => {
+      this.retryTimeout = undefined;
+      this.retryFailedLocations();
+    }, delay);
+  }
+
+  private async retryFailedLocations() {
+    const locations = Array.from(this.failedLocations);
+    if (this.destroyed || !locations.length) {
+      return;
+    }
+    // Each attempt that fails again calls `scheduleRetry`, which re-arms the timer, so the retry
+    // loop keeps going (with a longer delay each time) until the location loads or goes away.
+    await Promise.all(locations.map((location) => this.loadFromServer(location)));
+    this.notifySubscribers();
   }
 
   private notifySubscribers() {
@@ -137,6 +192,11 @@ export abstract class LocationBaseDataFetcher<TData, TVariables extends Operatio
   }
 
   public destroy() {
+    this.destroyed = true;
     this.unsubscribe();
+    if (this.retryTimeout) {
+      clearTimeout(this.retryTimeout);
+      this.retryTimeout = undefined;
+    }
   }
 }

--- a/js_modules/ui-core/src/workspace/WorkspaceContext/LocationBaseDataFetcher.ts
+++ b/js_modules/ui-core/src/workspace/WorkspaceContext/LocationBaseDataFetcher.ts
@@ -26,9 +26,10 @@ export abstract class LocationBaseDataFetcher<TData, TVariables extends Operatio
   private readonly key: string;
   private loadedFromCache: {[key: string]: boolean};
   private unsubscribe: () => void;
-  private failedLocations: Set<string> = new Set();
-  private retryAttempt = 0;
-  private retryTimeout: ReturnType<typeof setTimeout> | undefined;
+  // Retry bookkeeping is per location: a location that has been failing for a while must not
+  // push a location that just started failing to the back of a long backoff.
+  private retries: Map<string, {attempt: number; timeout?: ReturnType<typeof setTimeout>}> =
+    new Map();
   private destroyed = false;
   constructor(args: {
     readonly query: DocumentNode;
@@ -62,7 +63,7 @@ export abstract class LocationBaseDataFetcher<TData, TVariables extends Operatio
               const nextData = {...this.data};
               delete nextData[location];
               this.data = nextData;
-              this.clearFailure(location);
+              this.clearRetry(location);
               clearCachedData({
                 key: `${this.key}/${location}`,
               });
@@ -114,7 +115,7 @@ export abstract class LocationBaseDataFetcher<TData, TVariables extends Operatio
     if (!this.locationStatuses[location]) {
       // Wait for location statuses to be loaded. If we were retrying this location it no longer
       // exists as far as we know, so stop retrying it.
-      this.clearFailure(location);
+      this.clearRetry(location);
       return;
     }
     if (
@@ -122,7 +123,7 @@ export abstract class LocationBaseDataFetcher<TData, TVariables extends Operatio
       this.getVersion(this.data[location]) === this.locationStatuses[location].versionKey
     ) {
       // If the version hasn't changed then we don't need to load from the server
-      this.clearFailure(location);
+      this.clearRetry(location);
       return;
     }
     await TimingControls.loadFromServer(async () => {
@@ -138,10 +139,19 @@ export abstract class LocationBaseDataFetcher<TData, TVariables extends Operatio
         console.error(error);
         this.scheduleRetry(location);
       } else if (data) {
-        this.clearFailure(location);
         const nextData = {...this.data};
         nextData[location] = data;
         this.data = nextData;
+        if (this.getVersion(data) === this.locationStatuses[location]?.versionKey) {
+          this.clearRetry(location);
+        } else {
+          // The response is for a different version than the one the status poller has told us
+          // about. Concurrent requests for the same location share a single in-flight query
+          // (see `fetchData`), so a load kicked off after a version change can be served by an
+          // older request. The poller won't report that version change again, so ask again
+          // ourselves rather than leaving the UI pinned to the response we just got.
+          this.scheduleRetry(location);
+        }
         this.notifySubscribers();
       } else {
         console.error('No data or error returned from fetchLocationData');
@@ -150,39 +160,35 @@ export abstract class LocationBaseDataFetcher<TData, TVariables extends Operatio
     });
   }
 
-  private clearFailure(location: string) {
-    this.failedLocations.delete(location);
-    if (!this.failedLocations.size) {
-      this.retryAttempt = 0;
+  private clearRetry(location: string) {
+    const retry = this.retries.get(location);
+    if (retry?.timeout) {
+      clearTimeout(retry.timeout);
     }
+    this.retries.delete(location);
   }
 
   private scheduleRetry(location: string) {
     if (this.destroyed) {
       return;
     }
-    this.failedLocations.add(location);
-    if (this.retryTimeout) {
-      // A retry is already armed; it picks up every location in `failedLocations`.
+    const retry = this.retries.get(location);
+    if (retry?.timeout) {
+      // Already armed for this location.
       return;
     }
-    const delay = Math.min(RETRY_BASE_INTERVAL * 2 ** this.retryAttempt, RETRY_MAX_INTERVAL);
-    this.retryAttempt += 1;
-    this.retryTimeout = setTimeout(() => {
-      this.retryTimeout = undefined;
-      this.retryFailedLocations();
+    const attempt = retry?.attempt ?? 0;
+    const delay = Math.min(RETRY_BASE_INTERVAL * 2 ** attempt, RETRY_MAX_INTERVAL);
+    const timeout = setTimeout(() => {
+      const current = this.retries.get(location);
+      if (current) {
+        current.timeout = undefined;
+      }
+      // `loadFromServer` notifies subscribers itself on success, and re-arms this timer (with a
+      // longer delay) if the location fails again.
+      this.loadFromServer(location);
     }, delay);
-  }
-
-  private async retryFailedLocations() {
-    const locations = Array.from(this.failedLocations);
-    if (this.destroyed || !locations.length) {
-      return;
-    }
-    // Each attempt that fails again calls `scheduleRetry`, which re-arms the timer, so the retry
-    // loop keeps going (with a longer delay each time) until the location loads or goes away.
-    await Promise.all(locations.map((location) => this.loadFromServer(location)));
-    this.notifySubscribers();
+    this.retries.set(location, {attempt: attempt + 1, timeout});
   }
 
   private notifySubscribers() {
@@ -194,9 +200,8 @@ export abstract class LocationBaseDataFetcher<TData, TVariables extends Operatio
   public destroy() {
     this.destroyed = true;
     this.unsubscribe();
-    if (this.retryTimeout) {
-      clearTimeout(this.retryTimeout);
-      this.retryTimeout = undefined;
+    for (const location of Array.from(this.retries.keys())) {
+      this.clearRetry(location);
     }
   }
 }

--- a/js_modules/ui-core/src/workspace/WorkspaceContext/__tests__/LocationBaseDataFetcher.test.tsx
+++ b/js_modules/ui-core/src/workspace/WorkspaceContext/__tests__/LocationBaseDataFetcher.test.tsx
@@ -1,7 +1,11 @@
 import {waitFor} from '@testing-library/react';
 
 import {ApolloClient, DocumentNode} from '../../../apollo-client';
-import {LocationBaseDataFetcher} from '../LocationBaseDataFetcher';
+import {
+  LocationBaseDataFetcher,
+  RETRY_BASE_INTERVAL,
+  RETRY_MAX_INTERVAL,
+} from '../LocationBaseDataFetcher';
 import type {WorkspaceStatusPoller} from '../WorkspaceStatusPoller';
 import type {LocationStatusEntryFragment} from '../types/WorkspaceQueries.types';
 
@@ -147,5 +151,112 @@ describe('LocationBaseDataFetcher', () => {
     fetcher = createFetcher();
     fetcher.destroy();
     expect(statusPoller.unsubscribe).toHaveBeenCalled();
+  });
+
+  describe('retrying failed locations', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+      mockGetCachedData.mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    const triggerUpdate = () => {
+      statusPoller.trigger({
+        added: ['loc1'],
+        updated: [],
+        removed: [],
+        locationStatuses: {loc1: {versionKey: 'v2'}},
+      });
+    };
+
+    it('retries a location whose fetch errored, and notifies once it succeeds', async () => {
+      // The status poller only reports a location when its versionKey *changes*, so a dropped
+      // failure would leave the UI rendering the previous deployment's definitions forever.
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+      getData.mockResolvedValueOnce({data: undefined, error: new Error('code server down')});
+      getData.mockResolvedValue({data: {value: 'fresh', version: 'v2'}, error: null});
+
+      fetcher = createFetcher();
+      const subscriber = jest.fn();
+      fetcher.subscribe(subscriber);
+      triggerUpdate();
+
+      await jest.advanceTimersByTimeAsync(0);
+      expect(getData).toHaveBeenCalledTimes(1);
+      expect(subscriber).not.toHaveBeenCalledWith({loc1: {value: 'fresh', version: 'v2'}});
+
+      await jest.advanceTimersByTimeAsync(RETRY_BASE_INTERVAL);
+      expect(getData).toHaveBeenCalledTimes(2);
+      expect(subscriber).toHaveBeenCalledWith({loc1: {value: 'fresh', version: 'v2'}});
+
+      // Once the location loads there is nothing left to retry.
+      await jest.advanceTimersByTimeAsync(RETRY_MAX_INTERVAL * 2);
+      expect(getData).toHaveBeenCalledTimes(2);
+      consoleError.mockRestore();
+    });
+
+    it('retries a location that returned neither data nor an error', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+      getData.mockResolvedValueOnce({data: undefined, error: null});
+      getData.mockResolvedValue({data: {value: 'fresh', version: 'v2'}, error: null});
+
+      fetcher = createFetcher();
+      fetcher.subscribe(jest.fn());
+      triggerUpdate();
+
+      await jest.advanceTimersByTimeAsync(0);
+      expect(getData).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(RETRY_BASE_INTERVAL);
+      expect(getData).toHaveBeenCalledTimes(2);
+      consoleError.mockRestore();
+    });
+
+    it('backs off between retries and stops once destroyed', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+      getData.mockResolvedValue({data: undefined, error: new Error('still down')});
+
+      fetcher = createFetcher();
+      fetcher.subscribe(jest.fn());
+      triggerUpdate();
+
+      await jest.advanceTimersByTimeAsync(0);
+      expect(getData).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(RETRY_BASE_INTERVAL);
+      expect(getData).toHaveBeenCalledTimes(2);
+
+      // The next retry waits twice as long, so nothing happens at the base interval.
+      await jest.advanceTimersByTimeAsync(RETRY_BASE_INTERVAL);
+      expect(getData).toHaveBeenCalledTimes(2);
+
+      await jest.advanceTimersByTimeAsync(RETRY_BASE_INTERVAL);
+      expect(getData).toHaveBeenCalledTimes(3);
+
+      fetcher.destroy();
+      await jest.advanceTimersByTimeAsync(RETRY_MAX_INTERVAL * 4);
+      expect(getData).toHaveBeenCalledTimes(3);
+      consoleError.mockRestore();
+    });
+
+    it('stops retrying a location that was removed', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+      getData.mockResolvedValue({data: undefined, error: new Error('code server down')});
+
+      fetcher = createFetcher();
+      fetcher.subscribe(jest.fn());
+      triggerUpdate();
+
+      await jest.advanceTimersByTimeAsync(0);
+      expect(getData).toHaveBeenCalledTimes(1);
+
+      statusPoller.trigger({added: [], updated: [], removed: ['loc1'], locationStatuses: {}});
+      await jest.advanceTimersByTimeAsync(RETRY_MAX_INTERVAL * 2);
+      expect(getData).toHaveBeenCalledTimes(1);
+      consoleError.mockRestore();
+    });
   });
 });

--- a/js_modules/ui-core/src/workspace/WorkspaceContext/__tests__/LocationBaseDataFetcher.test.tsx
+++ b/js_modules/ui-core/src/workspace/WorkspaceContext/__tests__/LocationBaseDataFetcher.test.tsx
@@ -242,6 +242,76 @@ describe('LocationBaseDataFetcher', () => {
       consoleError.mockRestore();
     });
 
+    it('retries when the response is for a different version than the status poller reported', async () => {
+      // Concurrent loads for one location share a single in-flight query, so a load started
+      // after a version change can be served by an older request. The poller won't report that
+      // change again, so the fetcher has to notice and ask again itself.
+      getData.mockResolvedValueOnce({data: {value: 'previous', version: 'v1'}, error: null});
+      getData.mockResolvedValue({data: {value: 'current', version: 'v2'}, error: null});
+
+      fetcher = createFetcher();
+      const subscriber = jest.fn();
+      fetcher.subscribe(subscriber);
+      triggerUpdate();
+
+      await jest.advanceTimersByTimeAsync(0);
+      // The response is still committed -- it's newer than nothing -- but it isn't accepted as
+      // up to date.
+      expect(subscriber).toHaveBeenCalledWith({loc1: {value: 'previous', version: 'v1'}});
+      expect(getData).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(RETRY_BASE_INTERVAL);
+      expect(getData).toHaveBeenCalledTimes(2);
+      expect(subscriber).toHaveBeenCalledWith({loc1: {value: 'current', version: 'v2'}});
+
+      await jest.advanceTimersByTimeAsync(RETRY_MAX_INTERVAL * 2);
+      expect(getData).toHaveBeenCalledTimes(2);
+    });
+
+    it('backs off per location, so a new failure is not delayed by an older one', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const callsByLocation: Record<string, number> = {loc1: 0, loc2: 0};
+      getData.mockImplementation(async ({variables}: {variables: {name: string}}) => {
+        const {name} = variables;
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        callsByLocation[name] = callsByLocation[name]! + 1;
+        return {data: undefined, error: new Error(`${name} down`)};
+      });
+
+      fetcher = createFetcher();
+      fetcher.subscribe(jest.fn());
+
+      // Let loc1 fail three times so its next retry is 20s out.
+      statusPoller.trigger({
+        added: ['loc1'],
+        updated: [],
+        removed: [],
+        locationStatuses: {loc1: {versionKey: 'v1'}},
+      });
+      await jest.advanceTimersByTimeAsync(0);
+      await jest.advanceTimersByTimeAsync(RETRY_BASE_INTERVAL); // t=5s, attempt 2
+      await jest.advanceTimersByTimeAsync(RETRY_BASE_INTERVAL * 2); // t=15s, attempt 3
+      expect(callsByLocation.loc1).toBe(3);
+
+      // loc2 starts failing now. It should get its own base-interval retry rather than waiting
+      // for loc1's much longer backoff.
+      statusPoller.trigger({
+        added: ['loc2'],
+        updated: [],
+        removed: [],
+        locationStatuses: {loc1: {versionKey: 'v1'}, loc2: {versionKey: 'v1'}},
+      });
+      await jest.advanceTimersByTimeAsync(1000);
+      expect(callsByLocation.loc2).toBe(1);
+
+      await jest.advanceTimersByTimeAsync(RETRY_BASE_INTERVAL);
+      expect(callsByLocation.loc2).toBe(2);
+      expect(callsByLocation.loc1).toBe(3);
+
+      fetcher.destroy();
+      consoleError.mockRestore();
+    });
+
     it('stops retrying a location that was removed', async () => {
       const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
       getData.mockResolvedValue({data: undefined, error: new Error('code server down')});


### PR DESCRIPTION
## Summary & Motivation

Fixes #34170.

The report is that after redeploying a code location, the UI intermittently keeps rendering the
previous deployment's asset definitions and lineage — missing new assets, missing or wrong
dependencies, deleted assets still present, and different parts of the UI disagreeing with each
other. A hard reload doesn't help; clearing browser storage does. That points at the
IndexedDB-backed workspace cache rather than HTTP caching (`index.html` is already served
`Cache-Control: no-store`, and there is no service worker).

I couldn't reproduce it deterministically either, but reading through that path there are three
defects that each produce this symptom. All three are in the workspace data layer that backs
`assetEntries` / `locationEntries`, i.e. the asset graph.

### 1. A failed location fetch is dropped and never retried

`LocationBaseDataFetcher.loadFromServer` logged the error and returned. Nothing else ever asks it
to load that location again:

- `WorkspaceStatusPoller.checkForChanges` sets `this.statuses = nextStatuses` **before** notifying
  subscribers, and only notifies when a `versionKey` actually changes. Once the poller has observed
  the new `versionKey`, subsequent polls see no diff and emit nothing.
- `WorkspaceManager.refetchAll()` goes through the same `checkForChanges`, so even an explicit
  refresh from the UI doesn't recover the location.

So a single transient failure — very likely during a redeploy, when the code server is briefly
unreachable — leaves that location pinned to the previous deployment's data for the rest of the
session, silently. `WorkspaceContext` then merges the fresh `LocationWorkspaceQuery` half with the
stale `LocationWorkspaceAssetsQuery` half (or vice versa) in `mergeWorkspaceData`, which is where
"different parts of the UI show inconsistent asset information" comes from.

The fetcher now tracks failed locations and retries them on its own schedule, with per-location
exponential backoff (5s → 60s cap) so a durably broken location doesn't hammer the server with an
expensive query. Retries are cleared on success, when the location's data already matches the
current `versionKey`, and when the location is removed; timers are cleared on `destroy()`.

It also verifies the response before accepting a load as up to date. `fetchData` dedupes
concurrent requests on `key + variables + query version`, none of which include the location's
`versionKey`, so a load started after a version change can be served by an older in-flight
request. The response is still committed (it's newer than what we hold), but the retry stays armed
rather than being cleared, since the poller has already consumed that version change and won't
report it again.

### 2. `CacheManager`'s in-memory mirror could outlive the entry it mirrors

`getCacheManager` is memoized by key, so each `CacheManager` is a process-wide singleton holding a
`current` mirror of its one IndexedDB entry, populated by the first read.

- `clear()` deleted the IndexedDB entry but left `current` intact, so `getCachedData` kept serving
  the deleted entry. `LocationBaseDataFetcher` calls `clearCachedData` when a location is
  removed — this is "removed assets can still appear".
- A `clear()` landing while a read was suspended on IndexedDB was worse: the read resolved with the
  value it captured before the delete and wrote it back, resurrecting the entry.
- `get(version)` returned `current.data` without re-checking `version`, so once `current` was
  populated a caller asking for a different version got the wrong entry. The version check only
  ever ran on the read that populated the mirror.

`clear()` now drops the mirror, reads carry a generation stamp that `clear` invalidates, and the
version is checked on every read.

One thing I deliberately left alone: `set()` does not refresh `current`, so the mirror can be
older than IndexedDB between a write and the next page load. Managers are process-wide singletons
per key with no lifecycle, so making writes visible to reads turns them into write-through
in-memory caches whose contents outlive the page state they came from — I tried it, and workspace
data fetched by one `WorkspaceProvider` stayed readable after that provider was gone (it broke
`BaseFallthroughRoot.test.tsx`). That window also isn't load-bearing for this issue: the two
readers (`WorkspaceStatusPoller.loadFromCache`, `LocationBaseDataFetcher.loadFromCache`) each read
once per instance and are immediately followed by a server fetch. There's a comment on `set`
recording this.

### 3. An IndexedDB error could hang every reader of a key forever

The read path was `new Promise(async (res) => { ... })` with the memoized promise stored in
`currentAwaitable`. `IDBLRUCache.withDB` throws `IDBError` when the database can't be opened, and a
throw inside that async executor rejects nothing and resolves nothing — the memoized promise never
settles, so every subsequent `get` on that key awaits forever. Reads are now a plain async method
with the error handled, so a cache miss is reported instead of hanging.

## Test Plan

Full `ui-core` suite as CI runs it (per `js_modules/tox.ini`): **170 suites / 1424 tests passing**,
with `lint:ci` and `tsc` clean on the changed files.

Cases in `LocationBaseDataFetcher.test.tsx`:

- a location whose fetch errors is retried and notifies subscribers once it succeeds, and stops
  being retried after that
- a location that returns neither data nor an error is retried
- retries back off, and stop after `destroy()`
- a removed location stops being retried
- a response for a different version than the poller reported triggers another attempt
- backoff is per location, so a new failure isn't delayed by an older one

Cases in `useIndexedDBCachedQuery.test.tsx`:

- `getCachedData` doesn't return an entry cached under a different version, even after a read at
  the matching version populated the in-memory mirror
- `getCachedData` returns nothing after `clearCachedData`
- a read already suspended on IndexedDB when `clearCachedData` lands doesn't resurrect the entry

Of the first four `LocationBaseDataFetcher` cases plus the first two `useIndexedDBCachedQuery`
cases, six fail on `master` and pass with this change. "A removed location stops being retried"
passes trivially on `master`, since nothing is retried there at all; it guards the new retry loop
against leaking work for locations that have gone away. The three cases added while addressing
review feedback are written against the fixed behaviour and I haven't re-run those against
`master`.

Running the full suite is also what caught a regression in an earlier revision of this branch —
see the `set()` note in section 2.

## Changelog

[ui] Fixed a bug where the asset graph could keep showing a code location's previous definitions
and dependencies after it was redeployed, until browser storage was cleared.
