### PR TITLE
fix(dagster-powerbi): renew tokens on long polls and track refreshes by RequestId

### DIFF
--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
@@ -3,7 +3,6 @@ import json
 import time
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from functools import cached_property
 from typing import Any
 from urllib.parse import urlencode
 
@@ -58,6 +57,8 @@ class PowerBIToken(ConfigurableResource):
 
 
 MICROSOFT_LOGIN_URL = "https://login.microsoftonline.com/{tenant_id}/oauth2/token"
+# Covers the gap before the next poll.
+_TOKEN_REFRESH_OFFSET_SECONDS = 300
 
 
 class PowerBIServicePrincipal(ConfigurableResource):
@@ -71,6 +72,7 @@ class PowerBIServicePrincipal(ConfigurableResource):
         ..., description="The Entra tenant ID where service principal was created."
     )
     _api_token: str | None = PrivateAttr(default=None)
+    _api_token_expires_at: float = PrivateAttr(default=0.0)
 
     def get_api_token(self) -> str:
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
@@ -89,11 +91,14 @@ class PowerBIServicePrincipal(ConfigurableResource):
         response.raise_for_status()
         out = response.json()
         self._api_token = out["access_token"]
-        return out["access_token"]
+        self._api_token_expires_at = time.monotonic() + float(out["expires_in"])
+        return self._api_token
 
     @property
     def api_token(self) -> str:
-        if not self._api_token:
+        if self._api_token is None or time.monotonic() >= (
+            self._api_token_expires_at - _TOKEN_REFRESH_OFFSET_SECONDS
+        ):
             return self.get_api_token()
         return self._api_token
 
@@ -113,10 +118,6 @@ class PowerBIWorkspace(ConfigurableResource):
         description="The maximum time in seconds to wait for a refresh to complete.",
     )
 
-    @cached_property
-    def _api_token(self) -> str:
-        return self.credentials.api_token
-
     def _fetch(
         self,
         endpoint: str,
@@ -135,7 +136,7 @@ class PowerBIWorkspace(ConfigurableResource):
         """
         headers = {
             "Content-Type": "application/json",
-            "Authorization": f"Bearer {self._api_token}",
+            "Authorization": f"Bearer {self.credentials.api_token}",
         }
         base_url = f"{BASE_API_URL}/groups/{self.workspace_id}" if group_scoped else BASE_API_URL
         url = f"{base_url}/{endpoint}"
@@ -166,12 +167,12 @@ class PowerBIWorkspace(ConfigurableResource):
     @public
     def trigger_and_poll_refresh(self, dataset_id: str) -> None:
         """Triggers a refresh of a PowerBI dataset and polls until it completes or fails."""
-        self.trigger_refresh(dataset_id)
-        self.poll_refresh(dataset_id)
+        refresh_id = self.trigger_refresh(dataset_id)
+        self.poll_refresh(dataset_id, refresh_id)
 
     @public
-    def trigger_refresh(self, dataset_id: str) -> None:
-        """Triggers a refresh of a PowerBI dataset."""
+    def trigger_refresh(self, dataset_id: str) -> str:
+        """Triggers a refresh of a PowerBI dataset and returns the refresh id."""
         response = self._fetch(
             method="POST",
             endpoint=f"datasets/{dataset_id}/refreshes",
@@ -181,26 +182,35 @@ class PowerBIWorkspace(ConfigurableResource):
         if response.status_code != 202:
             raise Failure(f"Refresh failed to start: {response.content}")
 
+        # Docs list Location / x-ms-request-id, but a standard refresh actually returns RequestId
+        # (same uuid as history requestId).
+        refresh_id = response.headers.get("RequestId")
+        if not refresh_id:
+            raise Failure("Refresh started but the response did not include a RequestId header.")
+        return refresh_id
+
     @public
-    def poll_refresh(self, dataset_id: str) -> None:
-        """Polls the refresh status of a PowerBI dataset until it completes or fails."""
+    def poll_refresh(self, dataset_id: str, refresh_id: str) -> None:
+        """Polls a specific PowerBI dataset refresh until it completes or fails."""
         status = None
+        refresh_detail: dict[str, Any] = {}
 
         start = time.monotonic()
         while status not in ["Completed", "Failed"]:
             if time.monotonic() - start > self.refresh_timeout:
                 raise Failure(f"Refresh timed out after {self.refresh_timeout} seconds.")
 
-            last_refresh = self._fetch_json(
-                f"datasets/{dataset_id}/refreshes",
+            refresh_detail = self._fetch_json(
+                f"datasets/{dataset_id}/refreshes/{refresh_id}",
                 group_scoped=True,
-            )["value"][0]
-            status = last_refresh["status"]
+            )
+            status = refresh_detail.get("status")
 
-            time.sleep(self.refresh_poll_interval)
+            if status not in ["Completed", "Failed"]:
+                time.sleep(self.refresh_poll_interval)
 
         if status == "Failed":
-            error = last_refresh.get("serviceExceptionJson")
+            error = refresh_detail.get("serviceExceptionJson")
             raise Failure(f"Refresh failed: {error}")
 
     @cached_method

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
@@ -175,24 +175,30 @@ def test_refreshable_semantic_model(
 
     # materialize the semantic model
 
+    refresh_id = uuid.uuid4().hex
+    refresh_url = (
+        f"{BASE_API_URL}/groups/{workspace_id}/datasets/{SAMPLE_SEMANTIC_MODEL['id']}/refreshes"
+    )
     workspace_data_api_mocks.add(
         method=responses.POST,
-        url=f"{BASE_API_URL}/groups/{workspace_id}/datasets/{SAMPLE_SEMANTIC_MODEL['id']}/refreshes",
+        url=refresh_url,
         json={"notifyOption": "NoNotification"},
         status=202,
+        headers={"RequestId": refresh_id},
     )
 
     workspace_data_api_mocks.add(
         method=responses.GET,
-        url=f"{BASE_API_URL}/groups/{workspace_id}/datasets/{SAMPLE_SEMANTIC_MODEL['id']}/refreshes",
-        json={"value": [{"status": "Unknown"}]},
-        status=200,
+        url=f"{refresh_url}/{refresh_id}",
+        json={"status": "Unknown"},
+        status=202,
     )
     workspace_data_api_mocks.add(
         method=responses.GET,
-        url=f"{BASE_API_URL}/groups/{workspace_id}/datasets/{SAMPLE_SEMANTIC_MODEL['id']}/refreshes",
+        url=f"{refresh_url}/{refresh_id}",
         json={
-            "value": [{"status": "Completed" if success else "Failed", "serviceExceptionJson": {}}]
+            "status": "Completed" if success else "Failed",
+            "serviceExceptionJson": {},
         },
         status=200,
     )

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_resource.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_resource.py
@@ -52,7 +52,7 @@ def test_service_principal_auth() -> None:
     responses.add(
         method=responses.POST,
         url=MICROSOFT_LOGIN_URL.format(tenant_id=fake_tenant_id),
-        json={"access_token": fake_token},
+        json={"access_token": fake_token, "expires_in": 3600},
         status=200,
     )
 
@@ -69,3 +69,46 @@ def test_service_principal_auth() -> None:
     assert fake_client_id in responses.calls[0].request.body
     assert fake_client_secret in responses.calls[0].request.body
     assert responses.calls[1].request.headers["Authorization"] == f"Bearer {fake_token}"
+
+
+@responses.activate
+def test_service_principal_refreshes_token_five_minutes_early() -> None:
+    first_token = uuid.uuid4().hex
+    second_token = uuid.uuid4().hex
+    fake_workspace_id = uuid.uuid4().hex
+    fake_tenant_id = uuid.uuid4().hex
+
+    resource = PowerBIWorkspace(
+        credentials=PowerBIServicePrincipal(
+            client_id=uuid.uuid4().hex,
+            client_secret=uuid.uuid4().hex,
+            tenant_id=fake_tenant_id,
+        ),
+        workspace_id=fake_workspace_id,
+    )
+
+    login_url = MICROSOFT_LOGIN_URL.format(tenant_id=fake_tenant_id)
+    # Lifetime equals the refresh offset, so the next request treats the token as due.
+    responses.add(
+        method=responses.POST,
+        url=login_url,
+        json={"access_token": first_token, "expires_in": 300},
+        status=200,
+    )
+    responses.add(
+        method=responses.POST,
+        url=login_url,
+        json={"access_token": second_token, "expires_in": 3600},
+        status=200,
+    )
+
+    reports_url = f"{BASE_API_URL}/groups/{fake_workspace_id}/reports"
+    responses.add(method=responses.GET, url=reports_url, json={}, status=200)
+    responses.add(method=responses.GET, url=reports_url, json={}, status=200)
+
+    resource._fetch("reports")  # noqa: SLF001
+    resource._fetch("reports")  # noqa: SLF001
+
+    assert len(responses.calls) == 4
+    assert responses.calls[1].request.headers["Authorization"] == f"Bearer {first_token}"
+    assert responses.calls[3].request.headers["Authorization"] == f"Bearer {second_token}"


### PR DESCRIPTION
## Summary & Motivation

The workspace used to cache `credentials.api_token` on a `cached_property`, so long refresh polls 401 after about an hour. That cache sat on top of the one already on `PowerBIServicePrincipal`, so the token was stored twice. Token caching now lives only on the credentials, which is also how Microsoft's own clients (for example azure-identity) hold tokens. The workspace reads `api_token` on every request. `PowerBIServicePrincipal` renews about five minutes before `expires_in`.

Polling `GET .../refreshes` `value[0]` can treat an older `Completed` row as this run. We take `RequestId` from the 202 and poll `GET .../refreshes/{id}`. Microsoft [documents](https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/refresh-dataset-in-group) `Location` and `x-ms-request-id` on the trigger 202. The response we got during testing used `RequestId` instead, so that is what we poll with.

`trigger_and_poll_refresh` is unchanged. In-repo assets and the workspace component only call that. `@public` `trigger_refresh` now returns the id; `poll_refresh` requires it.

## Test Plan

- [x] `pytest` in `dagster-powerbi`
- [x] `make ruff`
- [x] ty on the diff
- [x] Live service-principal refresh
- [x] Live token re-login with a 3600s offset

## Changelog

- [dagster-powerbi] Fixed a 401 during long semantic model refresh polls by renewing the service principal token before it expires.
- [dagster-powerbi] Poll a specific refresh via `RequestId` instead of the first row of refresh history.
- [dagster-powerbi] **Breaking.** `trigger_refresh` now returns `str`. `poll_refresh` requires `refresh_id`. `trigger_and_poll_refresh` is unchanged.