### PR TITLE
[helm] Allow non-exec probe handlers for user deployments

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -129,7 +129,7 @@ spec:
             successThreshold: 1
             failureThreshold: 15
         {{- else if ne $deployment.readinessProbe.enabled false }}
-          {{- if not $deployment.readinessProbe.exec }}
+          {{- if not (or $deployment.readinessProbe.exec $deployment.readinessProbe.httpGet $deployment.readinessProbe.tcpSocket $deployment.readinessProbe.grpc) }}
           readinessProbe:
             exec:
               command: ["dagster", "api", "grpc-health-check", "-p", "{{ $deployment.port }}"]
@@ -162,7 +162,7 @@ spec:
           {{- end }}
         {{- end }}
         {{- if $deployment.livenessProbe }}
-          {{- if not $deployment.livenessProbe.exec }}
+          {{- if not (or $deployment.livenessProbe.exec $deployment.livenessProbe.httpGet $deployment.livenessProbe.tcpSocket $deployment.livenessProbe.grpc) }}
           livenessProbe:
             exec:
               command: ["dagster", "api", "grpc-health-check", "-p", "{{ $deployment.port }}"]
@@ -201,7 +201,7 @@ spec:
             {{- if $startupProbe }}
               {{- $startupProbe | toYaml | nindent 12 }}
             {{- end }}
-          {{- if not $deployment.startupProbe.exec }}
+          {{- if not (or $deployment.startupProbe.exec $deployment.startupProbe.httpGet $deployment.startupProbe.tcpSocket $deployment.startupProbe.grpc) }}
             exec:
               command: ["dagster", "api", "grpc-health-check", "-p", "{{ $deployment.port }}"]
           {{- end }}

--- a/helm/dagster/schema/schema_tests/test_user_deployments.py
+++ b/helm/dagster/schema/schema_tests/test_user_deployments.py
@@ -709,6 +709,69 @@ def test_liveness_probe_exec(template: HelmTemplate):
     ]
 
 
+def test_readiness_probe_grpc(template: HelmTemplate):
+    deployment = create_simple_user_deployment("foo")
+    deployment.readinessProbe = ReadinessProbeWithEnabled.construct(
+        enabled=True, grpc=dict(port=deployment.port)
+    )
+    helm_values = DagsterHelmValues.construct(
+        dagsterUserDeployments=UserDeployments.construct(deployments=[deployment])
+    )
+
+    dagster_user_deployment = template.render(helm_values)
+    assert len(dagster_user_deployment) == 1
+    dagster_user_deployment = dagster_user_deployment[0]
+
+    assert len(dagster_user_deployment.spec.template.spec.containers) == 1
+    container = dagster_user_deployment.spec.template.spec.containers[0]
+
+    assert container.readiness_probe.grpc.port == deployment.port
+    assert container.readiness_probe._exec is None  # noqa: SLF001
+
+
+def test_liveness_probe_tcp_socket(template: HelmTemplate):
+    deployment = create_simple_user_deployment("foo")
+    deployment.livenessProbe = kubernetes.LivenessProbe.construct(
+        tcpSocket=dict(port=deployment.port)
+    )
+    helm_values = DagsterHelmValues.construct(
+        dagsterUserDeployments=UserDeployments.construct(deployments=[deployment])
+    )
+
+    dagster_user_deployment = template.render(helm_values)
+    assert len(dagster_user_deployment) == 1
+    dagster_user_deployment = dagster_user_deployment[0]
+
+    assert len(dagster_user_deployment.spec.template.spec.containers) == 1
+    container = dagster_user_deployment.spec.template.spec.containers[0]
+
+    assert container.liveness_probe.tcp_socket.port == deployment.port
+    assert container.liveness_probe._exec is None  # noqa: SLF001
+
+
+def test_startup_probe_grpc(template: HelmTemplate):
+    deployment = create_simple_user_deployment("foo")
+    deployment.startupProbe = kubernetes.StartupProbe.construct(
+        enabled=True, grpc=dict(port=deployment.port)
+    )
+    helm_values = DagsterHelmValues.construct(
+        dagsterUserDeployments=UserDeployments.construct(deployments=[deployment])
+    )
+
+    dagster_user_deployment = template.render(helm_values)
+    assert len(dagster_user_deployment) == 1
+    dagster_user_deployment = dagster_user_deployment[0]
+
+    assert len(dagster_user_deployment.spec.template.spec.containers) == 1
+    container = dagster_user_deployment.spec.template.spec.containers[0]
+
+    # The default exec handler must not be appended alongside the supplied one:
+    # a probe may only specify a single handler.
+    assert container.startup_probe.grpc.port == deployment.port
+    assert container.startup_probe._exec is None  # noqa: SLF001
+
+
+
 @pytest.mark.parametrize("chart_version", ["0.11.0", "0.11.1"])
 def test_user_deployment_default_image_tag_is_chart_version(
     template: HelmTemplate, chart_version: str


### PR DESCRIPTION
## Summary & Motivation

Fixes #25868.

The `dagster-user-deployments` chart only renders a user-supplied probe verbatim when `exec` is set:

```gotemplate
{{- if not $deployment.readinessProbe.exec }}
  → default exec probe (+ any timing overrides)
{{- else }}
  → user's probe, verbatim
{{- end }}
```

Any other handler type therefore cannot be configured. Kubernetes has supported native gRPC probes GA since  1.27, which is a natural fit here — the code server already registers the standard `grpc.health.v1` service — but there is currently no way to ask for one.

Two concrete failure modes today:

- **readiness / liveness** — a supplied `grpc`, `httpGet` or `tcpSocket` handler is *silently discarded* and replaced by the default `exec` probe, with the user's timing fields grafted onto it. There is no warning; the chart renders successfully with a probe the user did not ask for.
- **startup** — the block is rendered verbatim and the default `exec` handler is then *appended*, producing a probe with two handlers, which Kubernetes rejects.

This widens the guard to test for any of the four handler types instead of only `exec`.

Practically, this lets operators replace a probe that spawns a full Python interpreter every `periodSeconds` (importing `dagster` purely to make one health RPC) with kubelet's native gRPC check, which costs no processes at all. On a code-location pod with a modest CPU limit that is a meaningful saving, and it removes a recurring source of probe timeouts.


## How I Tested These Changes

Added three schema tests alongside the existing `test_readiness_probe_exec` / `test_liveness_probe_exec` / `test_startup_probe_default_exec`:

- `test_readiness_probe_grpc`
- `test_liveness_probe_tcp_socket`
- `test_startup_probe_grpc` — asserts the default exec handler is *not* appended

Also rendered the chart directly with `helm template` across the matrix above to confirm the existing paths are byte-for-byte unchanged. For a `grpc` readiness probe plus a `grpc` startup probe:

**Before**
```yaml
readinessProbe:
  exec:
    command: ["dagster", "api", "grpc-health-check", "-p", "3030"]   # user's grpc handler dropped
  periodSeconds: 20
  failureThreshold: 3
startupProbe:
  failureThreshold: 30
  grpc:
    port: 3030
  exec:                                                              # two handlers
    command: ["dagster", "api", "grpc-health-check", "-p", "3030"]
```

**After**
```yaml
readinessProbe:
  failureThreshold: 3
  grpc:
    port: 3030
  periodSeconds: 20
startupProbe:
  failureThreshold: 30
  grpc:
    port: 3030
```
