### PR TITLE
Fix backfill CLI crash for long partition names in narrow terminals

### DIFF
--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -981,7 +981,10 @@ def print_partition_format(partitions: Sequence[str], indent_level: int) -> str:
         screen_width = 250
     max_str_len = max(len(x) for x in partitions)
     spacing = 10
-    num_columns = min(10, int((screen_width - indent_level) / (max_str_len + spacing)))
+    num_columns = max(
+        1,
+        min(10, int((screen_width - indent_level) / (max_str_len + spacing))),
+    )
     column_width = int((screen_width - indent_level) / num_columns)
     prefix = " " * max(0, indent_level - spacing)
     lines = [


### PR DESCRIPTION

  ### What's the issue?

  `dagster job backfill` can crash before submitting any runs when a partition name is longer than the available terminal
  width.

  The crash occurs in `dagster/_cli/job.py` inside `print_partition_format()`:

  ```python
  num_columns = min(
      10,
      int((screen_width - indent_level) / (max_str_len + spacing)),
  )
  column_width = int((screen_width - indent_level) / num_columns)
  ```
  For example, with an 80-column terminal, indent_level=15, and a 162-character partition name:
  ```python
  num_columns = int((80 - 15) / (162 + 10))
  # 0
  ```
  The next line raises:

  ZeroDivisionError: division by zero

  This happens while printing the backfill summary, before Launching runs..., so no backfill runs are submitted.

  The current implementation also invokes os.popen("stty size") without an explicit close, which can produce ResourceWarning
  output when the formatting error interrupts execution.

  ### Expected behavior

  Long partition names should be formatted using one column, or otherwise handled without crashing. Backfill selection and
  submission should not depend on partition names fitting within the terminal width.

  ### How to reproduce

  1. Create or use a partitioned job with a partition name at least 162 characters long.
  2. Run the backfill from a narrow terminal, such as 80 columns.
  3. Execute:

  dagster job backfill --job <job-name> --partitions <long-partition-name> --noprompt

  4. Observe:

  ZeroDivisionError: division by zero

  ### Dagster version

  1.13.18

  ### Changelog

  Fix backfill CLI crashes caused by long partition names in narrow terminals.