### PR TITLE
fix(dagster-dbt): fall back to building the child map when the dbt manifest lacks one

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -201,7 +201,15 @@ def _select_unique_ids_from_manifest(
         **functions,
     )
 
-    child_map = manifest_json["child_map"]
+    # Manifests produced by early versions of dbt Fusion do not contain a child
+    # map. Fall back to building one, the same way `build_dbt_specs` does. The
+    # import is deferred to avoid a circular import: `asset_utils` imports this
+    # module at its top level.
+    child_map = manifest_json.get("child_map")
+    if not child_map:
+        from dagster_dbt.asset_utils import _build_child_map
+
+        child_map = _build_child_map(manifest_json)
 
     graph = graph_selector.Graph(DiGraph(incoming_graph_data=child_map))
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -87,6 +87,24 @@ def _select_unique_ids_from_cli(
     return unique_ids - {None}
 
 
+def _build_selection_child_map(manifest_json: Mapping[str, Any]) -> Mapping[str, AbstractSet[str]]:
+    """Build a child map like dbt's native one, for selection on manifests without it.
+
+    Every resource appears as a node, and the edges are the direct inversion of
+    depends_on, matching the structure dbt writes into manifests that include a
+    child map.
+    """
+    child_map: dict[str, set[str]] = {}
+    for container in ("nodes", "sources", "exposures", "metrics", "semantic_models"):
+        for unique_id in manifest_json.get(container) or {}:
+            child_map.setdefault(unique_id, set())
+    for container in ("nodes", "exposures", "metrics", "semantic_models"):
+        for unique_id, resource in (manifest_json.get(container) or {}).items():
+            for parent_unique_id in resource.get("depends_on", {}).get("nodes", []):
+                child_map.setdefault(parent_unique_id, set()).add(unique_id)
+    return child_map
+
+
 def _select_unique_ids_from_manifest(
     select: str,
     exclude: str,
@@ -202,14 +220,13 @@ def _select_unique_ids_from_manifest(
     )
 
     # Manifests produced by early versions of dbt Fusion do not contain a child
-    # map. Fall back to building one, the same way `build_dbt_specs` does. The
-    # import is deferred to avoid a circular import: `asset_utils` imports this
-    # module at its top level.
+    # map. Fall back to building one with the same structure as dbt's native
+    # child map: every resource appears as a node, and the edges are the direct
+    # inversion of depends_on, so graph selectors resolve exposures, metrics
+    # and semantic models the same way they do on a manifest that includes one.
     child_map = manifest_json.get("child_map")
     if not child_map:
-        from dagster_dbt.asset_utils import _build_child_map
-
-        child_map = _build_child_map(manifest_json)
+        child_map = _build_selection_child_map(manifest_json)
 
     graph = graph_selector.Graph(DiGraph(incoming_graph_data=child_map))
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -95,13 +95,31 @@ def _build_selection_child_map(manifest_json: Mapping[str, Any]) -> Mapping[str,
     child map.
     """
     child_map: dict[str, set[str]] = {}
-    for container in ("nodes", "sources", "exposures", "metrics", "semantic_models"):
+    for container in (
+        "nodes",
+        "sources",
+        "exposures",
+        "functions",
+        "metrics",
+        "semantic_models",
+        "saved_queries",
+        "unit_tests",
+    ):
         for unique_id in manifest_json.get(container) or {}:
             child_map.setdefault(unique_id, set())
-    for container in ("nodes", "exposures", "metrics", "semantic_models"):
+    for container in (
+        "nodes",
+        "exposures",
+        "functions",
+        "metrics",
+        "semantic_models",
+        "saved_queries",
+        "unit_tests",
+    ):
         for unique_id, resource in (manifest_json.get(container) or {}).items():
             for parent_unique_id in resource.get("depends_on", {}).get("nodes", []):
-                child_map.setdefault(parent_unique_id, set()).add(unique_id)
+                if parent_unique_id in child_map:
+                    child_map[parent_unique_id].add(unique_id)
     return child_map
 
 
@@ -222,8 +240,7 @@ def _select_unique_ids_from_manifest(
     # Manifests produced by early versions of dbt Fusion do not contain a child
     # map. Fall back to building one with the same structure as dbt's native
     # child map: every resource appears as a node, and the edges are the direct
-    # inversion of depends_on, so graph selectors resolve exposures, metrics
-    # and semantic models the same way they do on a manifest that includes one.
+    # inversion of depends_on for all resource types supported by the manifest.
     child_map = manifest_json.get("child_map")
     if not child_map:
         child_map = _build_selection_child_map(manifest_json)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
@@ -13,6 +13,7 @@ from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.asset_utils import DBT_DEFAULT_EXCLUDE, DBT_DEFAULT_SELECT
 from dagster_dbt.compat import DBT_PYTHON_VERSION
 from dagster_dbt.dbt_manifest_asset_selection import DbtManifestAssetSelection
+from dagster_dbt.utils import select_unique_ids
 from dagster_shared.check.functions import ParameterCheckError
 
 from dagster_dbt_tests.dbt_projects import test_jaffle_shop_path
@@ -432,3 +433,56 @@ def test_dbt_asset_selection_selector_invalid(
             selector="fake_selector_does_not_exist",
         )
         def selected_dbt_assets(): ...
+
+
+def test_select_unique_ids_with_missing_child_map(
+    test_jaffle_shop_manifest: dict[str, Any],
+) -> None:
+    """Early dbt Fusion manifests do not contain a child map.
+
+    Selection should fall back to a child map that covers every resource type,
+    including exposures, so graph selectors resolve the same unique ids as the
+    native child map.
+    """
+    manifest = copy.deepcopy(test_jaffle_shop_manifest)
+    manifest["exposures"]["exposure.jaffle_shop.my_exposure"] = {
+        "unique_id": "exposure.jaffle_shop.my_exposure",
+        "name": "my_exposure",
+        "resource_type": "exposure",
+        "type": "analysis",
+        "owner": {"name": "me", "email": "me@example.com"},
+        "depends_on": {"nodes": ["model.jaffle_shop.customers"]},
+        "description": "",
+        "labels": {},
+        "state": "active",
+        "fqn": ["jaffle_shop", "my_exposure"],
+        "package_name": "jaffle_shop",
+        "path": "exposures.yml",
+        "original_file_path": "exposures.yml",
+        "created_at": 1.0,
+        "parent_id": None,
+    }
+    manifest["child_map"]["model.jaffle_shop.customers"].append("exposure.jaffle_shop.my_exposure")
+    manifest["child_map"]["exposure.jaffle_shop.my_exposure"] = []
+
+    native = select_unique_ids(
+        select="+exposure:my_exposure",
+        exclude="",
+        selector="",
+        project=None,
+        manifest_json=manifest,
+    )
+
+    fusion = copy.deepcopy(manifest)
+    fusion["metadata"]["dbt_version"] = "2.0.0"
+    del fusion["child_map"]
+
+    fallback = select_unique_ids(
+        select="+exposure:my_exposure",
+        exclude="",
+        selector="",
+        project=None,
+        manifest_json=fusion,
+    )
+
+    assert fallback == native

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
@@ -13,7 +13,7 @@ from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.asset_utils import DBT_DEFAULT_EXCLUDE, DBT_DEFAULT_SELECT
 from dagster_dbt.compat import DBT_PYTHON_VERSION
 from dagster_dbt.dbt_manifest_asset_selection import DbtManifestAssetSelection
-from dagster_dbt.utils import select_unique_ids
+from dagster_dbt.utils import _build_selection_child_map, select_unique_ids
 from dagster_shared.check.functions import ParameterCheckError
 
 from dagster_dbt_tests.dbt_projects import test_jaffle_shop_path
@@ -486,3 +486,68 @@ def test_select_unique_ids_with_missing_child_map(
     )
 
     assert fallback == native
+
+
+@pytest.mark.parametrize(
+    ["manifest_fixture", "resource_type", "minimum_version"],
+    [
+        ("test_dbt_semantic_models_manifest", "saved_query", "1.7.0"),
+        ("test_dbt_unit_tests_manifest", "unit_test", "1.8.0"),
+        ("test_dbt_functions_manifest", "function", "1.11.0"),
+    ],
+)
+@pytest.mark.parametrize("child_map", [None, {}], ids=["missing", "empty"])
+def test_select_other_resources_with_missing_child_map(
+    request: pytest.FixtureRequest,
+    manifest_fixture: str,
+    resource_type: str,
+    minimum_version: str,
+    child_map: dict[str, list[str]] | None,
+) -> None:
+    from packaging.version import Version
+
+    if DBT_PYTHON_VERSION is None or DBT_PYTHON_VERSION < Version(minimum_version):
+        pytest.skip(f"{resource_type} requires dbt {minimum_version}")
+
+    manifest = copy.deepcopy(request.getfixturevalue(manifest_fixture))
+    container = "saved_queries" if resource_type == "saved_query" else f"{resource_type}s"
+    resource_ids = set(manifest[container])
+    assert resource_ids
+
+    fallback_manifest = copy.deepcopy(manifest)
+    if child_map is None:
+        del fallback_manifest["child_map"]
+    else:
+        fallback_manifest["child_map"] = child_map
+
+    # Cover direct selection, ancestor traversal and indirect test selection.
+    selections = [f"resource_type:{resource_type}", f"+resource_type:{resource_type}", "*"]
+    if resource_type == "unit_test":
+        selections.append(" ".join(resource["model"] for resource in manifest[container].values()))
+    for selection in selections:
+        native = select_unique_ids(
+            select=selection, exclude="", selector="", project=None, manifest_json=manifest
+        )
+        assert resource_ids <= native
+        fallback = select_unique_ids(
+            select=selection, exclude="", selector="", project=None, manifest_json=fallback_manifest
+        )
+        assert fallback == native
+
+
+@pytest.mark.parametrize("container", ["functions", "saved_queries", "unit_tests"])
+def test_selection_child_map_dependencies(container: str) -> None:
+    manifest = {
+        "nodes": {"model.project.parent": {}},
+        container: {
+            "resource.project.child": {
+                "depends_on": {"nodes": ["model.project.parent", "model.project.missing"]}
+            },
+        },
+    }
+
+    # Match dbt's native child map: preserve known edges without adding unknown parents.
+    assert _build_selection_child_map(manifest) == {
+        "model.project.parent": {"resource.project.child"},
+        "resource.project.child": set(),
+    }

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_specs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_specs.py
@@ -1,7 +1,8 @@
-from collections.abc import Mapping
+import copy
+from collections.abc import Mapping, Sequence
 from typing import Any
 
-from dagster import AutomationCondition, Definitions
+from dagster import AssetSpec, AutomationCondition, Definitions
 from dagster_dbt.asset_specs import build_dbt_asset_specs
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
 
@@ -10,6 +11,24 @@ def test_build_dbt_asset_specs_as_external_assets(
     test_jaffle_shop_manifest: dict[str, Any],
 ) -> None:
     assert Definitions(assets=build_dbt_asset_specs(manifest=test_jaffle_shop_manifest))
+
+
+def test_build_dbt_asset_specs_with_missing_child_map(
+    test_jaffle_shop_manifest: dict[str, Any],
+) -> None:
+    """Manifests produced by early versions of dbt Fusion do not contain a child map.
+
+    Building asset specs from such a manifest should fall back to building the child map, not crash during selection.
+    """
+    manifest = copy.deepcopy(test_jaffle_shop_manifest)
+    manifest["metadata"]["dbt_version"] = "2.0.0"
+    del manifest["child_map"]
+
+    baseline: Sequence[AssetSpec] = build_dbt_asset_specs(manifest=test_jaffle_shop_manifest)
+    specs: Sequence[AssetSpec] = build_dbt_asset_specs(manifest=manifest)
+
+    assert [spec.key for spec in specs] == [spec.key for spec in baseline]
+    assert [spec.deps for spec in specs] == [spec.deps for spec in baseline]
 
 
 def test_build_dbt_asset_specs_preserves_translator_attributes(


### PR DESCRIPTION
## summary & motivation

`select_unique_ids` reads `manifest_json["child_map"]` during dbt selection. early dbt fusion manifests can omit this map, so building asset specs raises `KeyError: 'child_map'` before dependency fallback runs

this adds `_build_selection_child_map` when the map is missing or empty. it keeps nodes, sources, exposures, functions, metrics, semantic models, saved queries and unit tests, then inverts direct `depends_on.nodes` edges. like dbt's native builder, it ignores dependencies whose parent is absent from the manifest

keeping intermediate resources preserves graph selection, including ephemeral nodes. the existing asset-dependency helper remains separate because it collapses those nodes. populated child maps keep using the existing path

## test plan

regressions compare selection and asset specs against manifests with a native child map. coverage includes exposures, saved queries, unit tests and functions, missing and empty maps, parent-model selection with indirect unit tests, dependency edges and missing parents

the six new saved-query, unit-test and function cases failed before the fix on dbt 1.11.7

fresh validation on python 3.10.11, from the repo root

```sh
python -m pytest \
  python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py \
  python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_specs.py \
  python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_check_selection.py -q
```

- dbt 1.11.7: 37 passed
- dbt 1.10.20: 35 passed, 2 skipped because functions require dbt 1.11
- ruff 0.16.2 lint and format checks passed on both changed files, using `config/ruff.toml`
- `scripts/run-ty.py --env-dir ty/master` on both changed files: ty 0.0.74, 0 errors and 0 warnings
- `git diff --check` passed

these are focused local checks, not a full-suite or live fusion cli run. upstream buildkite validation remains pending

## changelog

fix(dagster-dbt): build asset specs from dbt manifests that lack a child map instead of crashing during selection
