### PR TITLE
Fix gRPC run cleanup race on startup failure

### DIFF
--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -1438,7 +1438,10 @@ class DagsterApiServer(DagsterApiServicer):
         # returning so that CanCancel will never return True
         if not success:
             with self._execution_lock:
-                self._clear_run(run_id)
+                # The cleanup thread may have already observed the process exit and
+                # cleared the run while this RPC was handling its startup failure.
+                if run_id in self._executions:
+                    self._clear_run(run_id)
 
         return dagster_api_pb2.StartRunReply(
             serialized_start_run_result=serialize_value(

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_launch_run.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_launch_run.py
@@ -1,9 +1,16 @@
+import threading
+from unittest.mock import MagicMock
+
 import dagster as dg
 from dagster._core.remote_representation.handle import JobHandle
 from dagster._core.storage.dagster_run import DagsterRunStatus
 from dagster._core.test_utils import create_run_for_test, poll_for_event, poll_for_finished_run
-from dagster._grpc.server import ExecuteExternalJobArgs
+from dagster._grpc.__generated__ import dagster_api_pb2
+from dagster._grpc.impl import IPCErrorMessage
+from dagster._grpc.server import DagsterApiServer, ExecuteExternalJobArgs
 from dagster._grpc.types import StartRunResult
+from dagster._serdes import serialize_value
+from dagster._utils.error import SerializableErrorInfo
 
 from dagster_tests.api_tests.utils import get_bar_repo_code_location
 
@@ -17,6 +24,68 @@ def _check_event_log_contains(event_log, expected_type_and_message):
             event_type == expected_event_type and expected_message_fragment in message
             for event_type, message in types_and_messages
         )
+
+
+def test_start_run_preserves_ipc_error_when_cleanup_wins_race():
+    with dg.instance_for_test() as instance:
+        with get_bar_repo_code_location(instance) as code_location:
+            job_handle = JobHandle("foo", code_location.get_repository("bar_repo").handle)
+            run_id = create_run_for_test(instance, "foo").run_id
+            execute_args = ExecuteExternalJobArgs(
+                job_origin=job_handle.get_remote_origin(),
+                run_id=run_id,
+                instance_ref=instance.get_ref(),
+            )
+            request = dagster_api_pb2.StartRunRequest(
+                serialized_execute_run_args=serialize_value(execute_args)
+            )
+            original_error = SerializableErrorInfo(
+                message="original IPC exception", stack=[], cls_name="OriginalError"
+            )
+
+            event_queue = MagicMock()
+            execution_process = MagicMock()
+            termination_event = MagicMock()
+            multiprocessing_context = MagicMock()
+            multiprocessing_context.Queue.return_value = event_queue
+            multiprocessing_context.Event.return_value = termination_event
+            multiprocessing_context.Process.return_value = execution_process
+
+            reconstructable_repository = MagicMock()
+            loaded_repositories = MagicMock()
+            loaded_repositories.reconstructables_by_name = {
+                execute_args.job_origin.repository_origin.repository_name: (
+                    reconstructable_repository
+                )
+            }
+
+            server = DagsterApiServer.__new__(DagsterApiServer)
+            server._shutdown_once_executions_finish_event = threading.Event()  # noqa: SLF001
+            server._loaded_repositories = loaded_repositories  # noqa: SLF001
+            server._mp_ctx = multiprocessing_context  # noqa: SLF001
+            server._execution_lock = threading.Lock()  # noqa: SLF001
+            server._executions = {}  # noqa: SLF001
+            server._termination_events = {}  # noqa: SLF001
+            server._termination_times = {}  # noqa: SLF001
+
+            def cleanup_then_return_ipc_error():
+                with server._execution_lock:  # noqa: SLF001
+                    server._clear_run(run_id)  # noqa: SLF001
+                return IPCErrorMessage(
+                    serializable_error_info=original_error,
+                    message="startup failed",
+                )
+
+            event_queue.get_nowait.side_effect = cleanup_then_return_ipc_error
+
+            reply = server.StartRun(request, MagicMock())
+            result = dg.deserialize_value(reply.serialized_start_run_result, StartRunResult)
+
+            assert not result.success
+            assert result.message == "startup failed"
+            assert result.serializable_error_info == original_error
+            assert server._executions == {}  # noqa: SLF001
+            assert server._termination_events == {}  # noqa: SLF001
 
 
 def test_launch_run_with_unloadable_job_grpc():


### PR DESCRIPTION
## Summary & Motivation

  The gRPC cleanup thread can observe that a run subprocess has exited and remove the run while the `StartRun` RPC is still handling the subprocess's startup failure.

  When `StartRun` subsequently attempted to clear the same run, `_clear_run()` raised a `KeyError`. This replaced the
  original IPC error with a gRPC `UNKNOWN` response.

  This change checks whether the run is still registered while holding `_execution_lock` before clearing it from `StartRun`.
  `_clear_run()` remains strict so unexpected bookkeeping inconsistencies are not silently ignored.

  ## Test Plan

  - Added a deterministic regression test that simulates the cleanup thread removing the run before `StartRun` finishes
  handling an `IPCErrorMessage`.
  - Verified that `StartRunResult` preserves the original `serializable_error_info`.
  - Ran `python_modules/dagster/dagster_tests/api_tests`: 72 passed, 1 skipped.
  - Ran Ruff lint and formatting checks.