### PR TITLE
[dagster-dbt] Treat `no-op`, `reused` and `warn` node statuses as successful

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/utils.py
@@ -13,6 +13,7 @@ from dagster import (
 from dagster._core.definitions.metadata import RawMetadataValue
 
 from dagster_dbt.cloud.types import DbtCloudOutput
+from dagster_dbt.compat import SUCCESSFUL_NODE_STATUSES
 from dagster_dbt.utils import ASSET_RESOURCE_TYPES, default_node_info_to_asset_key
 
 
@@ -110,7 +111,7 @@ def result_to_events(
 
     node_resource_type = _resource_type(unique_id)
 
-    if node_resource_type in ASSET_RESOURCE_TYPES and status == "success":
+    if node_resource_type in ASSET_RESOURCE_TYPES and status in SUCCESSFUL_NODE_STATUSES:
         if generate_asset_outputs:
             yield Output(
                 value=None,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
@@ -86,15 +86,29 @@ class DbtCloudJobRunHandler:
             return None
 
 
-def get_completed_at_timestamp(result: Mapping[str, Any]) -> float:
+def get_completed_at_timestamp(
+    result: Mapping[str, Any], fallback_timestamp: float | None = None
+) -> float:
     timing = result["timing"]
     if len(timing) == 0:
-        # as a fallback, use the current timestamp
-        return get_current_timestamp()
+        # Nodes that dbt did not actually build -- e.g. `no-op` and `reused` -- can have no
+        # timing entries. Fall back to a timestamp belonging to the run itself rather than to
+        # the current time: the polling sensor sorts an asset's events by this value, so a
+        # wall-clock fallback would make an older run look newer than a run that really did
+        # rebuild the node.
+        return fallback_timestamp if fallback_timestamp is not None else get_current_timestamp()
     # result["timing"] is a list of events in run_results.json
     # For successful models and passing tests,
     # the last item of that list includes the timing details of the execution.
     return parser.parse(result["timing"][-1]["completed_at"]).timestamp()
+
+
+def get_run_generated_at_timestamp(run_results: Mapping[str, Any]) -> float:
+    """When the run's artifacts were generated, used as the completion timestamp for nodes
+    that dbt reported without any timing entries.
+    """
+    generated_at = run_results.get("metadata", {}).get("generated_at")
+    return parser.parse(generated_at).timestamp() if generated_at else get_current_timestamp()
 
 
 @record
@@ -148,6 +162,7 @@ class DbtCloudJobRunResults:
         run = DbtCloudRun.from_run_details(run_details=client.get_run_details(run_id=self.run_id))
 
         invocation_id: str = self.run_results["metadata"]["invocation_id"]
+        generated_at_timestamp: float = get_run_generated_at_timestamp(self.run_results)
         for result in self.run_results["results"]:
             unique_id: str = result["unique_id"]
             dbt_resource_props: Mapping[str, Any] = manifest["nodes"].get(unique_id)
@@ -197,7 +212,9 @@ class DbtCloudJobRunResults:
                     **default_metadata,
                     "status": result_status,
                     COMPLETED_AT_TIMESTAMP_METADATA_KEY: MetadataValue.timestamp(
-                        get_completed_at_timestamp(result=result)
+                        get_completed_at_timestamp(
+                            result=result, fallback_timestamp=generated_at_timestamp
+                        )
                     ),
                 }
                 if context and has_asset_def:
@@ -217,7 +234,9 @@ class DbtCloudJobRunResults:
                     **default_metadata,
                     "status": result_status,
                     COMPLETED_AT_TIMESTAMP_METADATA_KEY: MetadataValue.timestamp(
-                        get_completed_at_timestamp(result=result)
+                        get_completed_at_timestamp(
+                            result=result, fallback_timestamp=generated_at_timestamp
+                        )
                     ),
                 }
                 failure_count = result.get("failures")

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
@@ -20,7 +20,7 @@ from requests.exceptions import RequestException
 from dagster_dbt.asset_utils import build_dbt_specs, get_asset_check_key_for_test
 from dagster_dbt.cloud_v2.client import DbtCloudWorkspaceClient
 from dagster_dbt.cloud_v2.types import DbtCloudRun
-from dagster_dbt.compat import REFABLE_NODE_TYPES, NodeStatus, NodeType, TestStatus
+from dagster_dbt.compat import REFABLE_NODE_TYPES, SUCCESSFUL_NODE_STATUSES, NodeType, TestStatus
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
 
 COMPLETED_AT_TIMESTAMP_METADATA_KEY = "dagster_dbt/completed_at_timestamp"
@@ -189,12 +189,13 @@ class DbtCloudJobRunResults:
 
             if (
                 resource_type in REFABLE_NODE_TYPES
-                and result_status == NodeStatus.Success
+                and result_status in SUCCESSFUL_NODE_STATUSES
                 and not is_ephemeral
             ):
                 spec = asset_specs[0]
                 metadata = {
                     **default_metadata,
+                    "status": result_status,
                     COMPLETED_AT_TIMESTAMP_METADATA_KEY: MetadataValue.timestamp(
                         get_completed_at_timestamp(result=result)
                     ),

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/compat.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/compat.py
@@ -106,10 +106,21 @@ else:
             Skipped = NodeStatus.Skipped
 
 
-# The statuses a refable node (model, seed, snapshot) can end on without having failed. `no-op`
-# (dbt 1.10+) and `reused` (dbt 1.12+) are terminal, non-error statuses meaning dbt deliberately
-# did not rebuild the node, so downstream nodes are free to run. Neither is a member of
-# `NodeStatus` on every dbt version dagster-dbt supports, hence the string literals.
-SUCCESSFUL_NODE_STATUSES: frozenset[str] = frozenset({"success", "no-op", "reused"})
+# The statuses a refable node (model, seed, snapshot) can end on without having failed.
+#
+# Use this ONLY for refable nodes -- it is not valid for tests. `warn` is a success for a
+# refable node but a warn-severity failure for a test, and the two are indistinguishable on the
+# wire, so the test path must keep comparing against `TestStatus` instead.
+#
+# - `no-op` (dbt-core 1.10+) and `reused` (dbt-core 1.12+, and every `Reused*` variant in dbt
+#   Fusion) are terminal, non-error statuses meaning dbt deliberately did not rebuild the node.
+# - `warn` is what dbt Fusion serializes its `SucceededWithWarning` status to: the node built
+#   successfully but emitted a warning (e.g. duplicate columns). Fusion itself maps that status
+#   to a successful `NodeOutcome`, and dbt-core's `RunStatus` has no `warn` member at all, so
+#   accepting it here cannot mask a dbt-core failure.
+#
+# These are spelled as string literals because none of them is a `NodeStatus` member across the
+# whole `dbt-core>=1.7,<1.12` range that dagster-dbt supports.
+SUCCESSFUL_NODE_STATUSES: frozenset[str] = frozenset({"success", "no-op", "reused", "warn"})
 
 logging.getLogger().handlers = existing_root_logger_handlers

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/compat.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/compat.py
@@ -95,6 +95,8 @@ else:
             PartialSuccess = "partial success"
             Pass = "pass"
             RuntimeErr = "runtime error"
+            NoOp = "no-op"
+            Reused = "reused"
 
         class TestStatus(StrEnum):
             Pass = NodeStatus.Pass
@@ -103,5 +105,11 @@ else:
             Warn = NodeStatus.Warn
             Skipped = NodeStatus.Skipped
 
+
+# The statuses a refable node (model, seed, snapshot) can end on without having failed. `no-op`
+# (dbt 1.10+) and `reused` (dbt 1.12+) are terminal, non-error statuses meaning dbt deliberately
+# did not rebuild the node, so downstream nodes are free to run. Neither is a member of
+# `NodeStatus` on every dbt version dagster-dbt supports, hence the string literals.
+SUCCESSFUL_NODE_STATUSES: frozenset[str] = frozenset({"success", "no-op", "reused"})
 
 logging.getLogger().handlers = existing_root_logger_handlers

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
@@ -33,7 +33,13 @@ from dagster_dbt.asset_utils import (
     get_asset_check_key_for_test,
     get_checks_on_sources_upstream_of_selected_assets,
 )
-from dagster_dbt.compat import REFABLE_NODE_TYPES, NodeStatus, NodeType, TestStatus
+from dagster_dbt.compat import (
+    REFABLE_NODE_TYPES,
+    SUCCESSFUL_NODE_STATUSES,
+    NodeStatus,
+    NodeType,
+    TestStatus,
+)
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, validate_translator
 from dagster_dbt.dbt_manifest import DbtManifestParam, validate_manifest
 from dagster_dbt.dbt_project import DbtProject
@@ -272,7 +278,7 @@ class DbtCliEventMessage(ABC):
         return (
             resource_props["resource_type"] in REFABLE_NODE_TYPES
             and materialized_type != "ephemeral"
-            and self._get_node_status() == NodeStatus.Success
+            and self._get_node_status() in SUCCESSFUL_NODE_STATUSES
         )
 
     def _is_test_execution_event(self, manifest: Mapping[str, Any]) -> bool:
@@ -388,6 +394,7 @@ class DbtCliEventMessage(ABC):
         return {
             **self._get_default_metadata(manifest),
             **self._get_lineage_metadata(translator, manifest, target_path, project),
+            "status": self._get_node_status(),
         }
 
     def _to_model_events(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_utils.py
@@ -1,0 +1,45 @@
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from dagster import AssetMaterialization
+from dagster_dbt.cloud.utils import result_to_events
+
+SAMPLE_RUN_RESULTS = json.loads(
+    Path(__file__).parent.joinpath("sample_run_results.json").read_text()
+)
+
+
+def refable_result(status: str) -> dict[str, Any]:
+    result = copy.deepcopy(SAMPLE_RUN_RESULTS["results"][0])
+    result["status"] = status
+    if status != "success":
+        # dbt records no timings for a node it never built.
+        result["timing"] = []
+    return result
+
+
+def materializations_for(status: str) -> list[AssetMaterialization]:
+    return [
+        event
+        for event in result_to_events(refable_result(status))
+        if isinstance(event, AssetMaterialization)
+    ]
+
+
+@pytest.mark.parametrize("status", ["success", "no-op", "reused"])
+def test_non_error_statuses_materialize(status: str) -> None:
+    """`no-op` (dbt-core 1.10+) and `reused` (dbt-core 1.12+) are terminal, non-error statuses
+    meaning dbt did not rebuild the node, so the model should still be materialized.
+    """
+    materializations = materializations_for(status)
+
+    assert len(materializations) == 1
+    assert materializations[0].metadata["Status"].value == status
+
+
+@pytest.mark.parametrize("status", ["error", "fail", "skipped", "runtime error"])
+def test_error_statuses_do_not_materialize(status: str) -> None:
+    assert materializations_for(status) == []

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_utils.py
@@ -29,7 +29,7 @@ def materializations_for(status: str) -> list[AssetMaterialization]:
     ]
 
 
-@pytest.mark.parametrize("status", ["success", "no-op", "reused"])
+@pytest.mark.parametrize("status", ["success", "no-op", "reused", "warn"])
 def test_non_error_statuses_materialize(status: str) -> None:
     """`no-op` (dbt-core 1.10+) and `reused` (dbt-core 1.12+) are terminal, non-error statuses
     meaning dbt did not rebuild the node, so the model should still be materialized.

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_run_events.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_run_events.py
@@ -1,5 +1,6 @@
 import copy
 
+import pytest
 import responses
 from dagster import AssetCheckEvaluation, AssetMaterialization
 from dagster_dbt.cloud_v2.resources import DbtCloudWorkspace
@@ -67,3 +68,60 @@ def test_default_asset_events_from_run_results_missing_failures_key(
     # Without a `failures` count, we should not attach failed row count metadata.
     for check_eval in asset_check_evaluations:
         assert "dagster_dbt/failed_row_count" not in check_eval.metadata
+
+
+@pytest.mark.parametrize("status", ["no-op", "reused"])
+def test_default_asset_events_from_run_results_non_error_statuses(
+    status: str,
+    workspace: DbtCloudWorkspace,
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+):
+    """`no-op` and `reused` are terminal, non-error dbt statuses meaning the node was not rebuilt.
+    The models they are reported for should still materialize rather than be dropped as failures.
+    """
+    run_results_json = copy.deepcopy(dict(get_sample_run_results_json()))
+    for result in run_results_json["results"]:
+        if result["status"] == "success":
+            result["status"] = status
+            # dbt does not record timings for a node it never built.
+            result["timing"] = []
+
+    run_results = DbtCloudJobRunResults.from_run_results_json(run_results_json=run_results_json)
+
+    events = list(
+        run_results.to_default_asset_events(
+            client=workspace.get_client(),
+            manifest=workspace.get_or_fetch_workspace_data().manifest,
+        )
+    )
+
+    asset_materializations = [event for event in events if isinstance(event, AssetMaterialization)]
+    asset_check_evaluations = [event for event in events if isinstance(event, AssetCheckEvaluation)]
+
+    assert len(asset_materializations) == 8
+    assert len(asset_check_evaluations) == 20
+
+    # The status is surfaced as metadata so that it is visible that nothing was built.
+    for materialization in asset_materializations:
+        assert materialization.metadata["status"].value == status
+
+
+def test_default_asset_events_from_run_results_error_status(
+    workspace: DbtCloudWorkspace, fetch_workspace_data_api_mocks: responses.RequestsMock
+):
+    """Models that errored are still not materialized."""
+    run_results_json = copy.deepcopy(dict(get_sample_run_results_json()))
+    for result in run_results_json["results"]:
+        if result["status"] == "success":
+            result["status"] = "error"
+
+    run_results = DbtCloudJobRunResults.from_run_results_json(run_results_json=run_results_json)
+
+    events = list(
+        run_results.to_default_asset_events(
+            client=workspace.get_client(),
+            manifest=workspace.get_or_fetch_workspace_data().manifest,
+        )
+    )
+
+    assert [event for event in events if isinstance(event, AssetMaterialization)] == []

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_run_events.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_run_events.py
@@ -74,7 +74,7 @@ def test_default_asset_events_from_run_results_missing_failures_key(
         assert "dagster_dbt/failed_row_count" not in check_eval.metadata
 
 
-@pytest.mark.parametrize("status", ["no-op", "reused"])
+@pytest.mark.parametrize("status", ["no-op", "reused", "warn"])
 def test_default_asset_events_from_run_results_non_error_statuses(
     status: str,
     workspace: DbtCloudWorkspace,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_run_events.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_run_events.py
@@ -4,7 +4,11 @@ import pytest
 import responses
 from dagster import AssetCheckEvaluation, AssetMaterialization
 from dagster_dbt.cloud_v2.resources import DbtCloudWorkspace
-from dagster_dbt.cloud_v2.run_handler import DbtCloudJobRunResults
+from dagster_dbt.cloud_v2.run_handler import (
+    COMPLETED_AT_TIMESTAMP_METADATA_KEY,
+    DbtCloudJobRunResults,
+)
+from dateutil import parser
 
 from dagster_dbt_tests.cloud_v2.conftest import TEST_RUN_URL, get_sample_run_results_json
 
@@ -125,3 +129,37 @@ def test_default_asset_events_from_run_results_error_status(
     )
 
     assert [event for event in events if isinstance(event, AssetMaterialization)] == []
+
+
+@pytest.mark.parametrize("status", ["no-op", "reused"])
+def test_timing_less_results_use_the_run_generated_at_timestamp(
+    status: str,
+    workspace: DbtCloudWorkspace,
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+):
+    """A node dbt never built can have no timing entries. The completion timestamp must come
+    from the run's own `generated_at` rather than the current time -- the polling sensor sorts
+    an asset's events by it, so a wall-clock fallback would make an older run that skipped the
+    node sort ahead of a newer run that actually rebuilt it.
+    """
+    run_results_json = copy.deepcopy(dict(get_sample_run_results_json()))
+    for result in run_results_json["results"]:
+        if result["status"] == "success":
+            result["status"] = status
+            result["timing"] = []
+
+    expected = parser.parse(run_results_json["metadata"]["generated_at"]).timestamp()
+
+    run_results = DbtCloudJobRunResults.from_run_results_json(run_results_json=run_results_json)
+
+    events = list(
+        run_results.to_default_asset_events(
+            client=workspace.get_client(),
+            manifest=workspace.get_or_fetch_workspace_data().manifest,
+        )
+    )
+
+    asset_materializations = [event for event in events if isinstance(event, AssetMaterialization)]
+    assert len(asset_materializations) == 8
+    for materialization in asset_materializations:
+        assert materialization.metadata[COMPLETED_AT_TIMESTAMP_METADATA_KEY].value == expected

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_sensor.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_sensor.py
@@ -49,6 +49,7 @@ def test_asset_materializations(
         "invocation_id",
         "run_url",
         "execution_duration",
+        "status",
     }
     assert set(first_asset_mat.metadata.keys()) == expected_metadata_keys
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_dbt_cli_event.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_dbt_cli_event.py
@@ -1,0 +1,87 @@
+import pytest
+from dagster import AssetMaterialization
+from dagster_dbt.core.dbt_cli_event import DbtCoreCliEventMessage
+from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
+
+MANIFEST = {
+    "metadata": {
+        "invocation_id": "c630c6bf-633e-4612-8e46-2f170224066c",
+        "generated_at": "2025-03-10T12:54:41.369662Z",
+    },
+    "nodes": {
+        "model.pytest_dwh.public__orders": {
+            "unique_id": "model.pytest_dwh.public__orders",
+            "name": "public__orders",
+            "resource_type": "model",
+            "materialized": "incremental",
+            "database": "dev",
+            "schema": "public",
+            "alias": "order_history",
+            "path": "mart/public__orders.sql",
+            "config": {"schema": "public"},
+            "description": "",
+        }
+    },
+}
+
+
+def build_log_model_result(node_status: str) -> DbtCoreCliEventMessage:
+    return DbtCoreCliEventMessage(
+        raw_event={
+            "data": {
+                "description": "sql incremental model public.orders",
+                "execution_time": 0.1,
+                "index": 1,
+                "node_info": {
+                    "materialized": "incremental",
+                    "node_finished_at": "2025-03-10T12:53:48.818126",
+                    "node_name": "public__orders",
+                    "node_path": "mart/public__orders.sql",
+                    "node_started_at": "2025-03-10T12:53:36.820592",
+                    "node_status": node_status,
+                    "resource_type": "model",
+                    "unique_id": "model.pytest_dwh.public__orders",
+                },
+                "status": node_status.upper(),
+                "total": 1,
+            },
+            "info": {
+                "invocation_id": "c630c6bf-633e-4612-8e46-2f170224066c",
+                "level": "info",
+                "msg": "1 of 1 OK",
+                "name": "LogModelResult",
+            },
+        },
+        event_history_metadata={},
+    )
+
+
+@pytest.mark.parametrize("node_status", ["success", "no-op", "reused"])
+def test_non_error_node_statuses_materialize(node_status: str) -> None:
+    """`no-op` (dbt 1.10+) and `reused` (dbt 1.12+) are terminal, non-error statuses meaning dbt
+    did not rebuild the node. They must materialize the asset rather than be treated as failures,
+    otherwise the missing materialization cascades to downstream assets.
+    """
+    events = list(
+        build_log_model_result(node_status).to_default_asset_events(
+            MANIFEST, DagsterDbtTranslator()
+        )
+    )
+
+    assert len(events) == 1
+    materialization = events[0]
+    assert isinstance(materialization, AssetMaterialization)
+    assert materialization.asset_key.path == ["public", "public__orders"]
+    # The status is surfaced as metadata so that it is visible that nothing was built.
+    assert materialization.metadata["status"].value == node_status
+
+
+@pytest.mark.parametrize("node_status", ["error", "fail", "skipped", "runtime error"])
+def test_error_node_statuses_do_not_materialize(node_status: str) -> None:
+    events = list(
+        build_log_model_result(node_status).to_default_asset_events(
+            MANIFEST, DagsterDbtTranslator()
+        )
+    )
+
+    assert events == []

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_dbt_cli_event.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_dbt_cli_event.py
@@ -1,5 +1,5 @@
 import pytest
-from dagster import AssetMaterialization
+from dagster import AssetCheckEvaluation, AssetCheckSeverity, AssetMaterialization
 from dagster_dbt.core.dbt_cli_event import DbtCoreCliEventMessage
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
 
@@ -56,11 +56,14 @@ def build_log_model_result(node_status: str) -> DbtCoreCliEventMessage:
     )
 
 
-@pytest.mark.parametrize("node_status", ["success", "no-op", "reused"])
+@pytest.mark.parametrize("node_status", ["success", "no-op", "reused", "warn"])
 def test_non_error_node_statuses_materialize(node_status: str) -> None:
-    """`no-op` (dbt 1.10+) and `reused` (dbt 1.12+) are terminal, non-error statuses meaning dbt
-    did not rebuild the node. They must materialize the asset rather than be treated as failures,
-    otherwise the missing materialization cascades to downstream assets.
+    """Statuses a refable node can end on without having failed must materialize the asset,
+    rather than be silently dropped.
+
+    `no-op` (dbt-core 1.10+) and `reused` (dbt-core 1.12+, and dbt Fusion's `Reused*` variants)
+    mean dbt deliberately did not rebuild the node. `warn` is what dbt Fusion serializes
+    `SucceededWithWarning` to -- the node did build, it just emitted a warning.
     """
     events = list(
         build_log_model_result(node_status).to_default_asset_events(
@@ -85,3 +88,65 @@ def test_error_node_statuses_do_not_materialize(node_status: str) -> None:
     )
 
     assert events == []
+
+
+WARNED_TEST_MANIFEST = {
+    "metadata": MANIFEST["metadata"],
+    "nodes": {
+        **MANIFEST["nodes"],
+        "test.pytest_dwh.unique_orders": {
+            "unique_id": "test.pytest_dwh.unique_orders",
+            "name": "unique_orders",
+            "resource_type": "test",
+            "materialized": "test",
+            "database": "dev",
+            "schema": "public",
+            "alias": "unique_orders",
+            "path": "unique_orders.sql",
+            "config": {"schema": "public"},
+            "description": "",
+            "depends_on": {"nodes": ["model.pytest_dwh.public__orders"]},
+            "attached_node": "model.pytest_dwh.public__orders",
+        },
+    },
+}
+
+
+def test_warn_on_a_test_is_still_a_warn_severity_check() -> None:
+    """`warn` means opposite things either side of the resource-type gate: a success for a
+    refable node, but a warn-severity check failure for a test. dbt serializes both to the same
+    string, so accepting `warn` for models must not leak into the test path.
+    """
+    event = DbtCoreCliEventMessage(
+        raw_event={
+            "data": {
+                "node_info": {
+                    "node_status": "warn",
+                    "node_name": "unique_orders",
+                    "resource_type": "test",
+                    "unique_id": "test.pytest_dwh.unique_orders",
+                    "node_started_at": "2025-03-10T12:53:36.820592",
+                    "node_finished_at": "2025-03-10T12:53:48.818126",
+                },
+                "status": "WARN",
+                "num_failures": 3,
+            },
+            "info": {
+                "invocation_id": "c630c6bf-633e-4612-8e46-2f170224066c",
+                "level": "warn",
+                "msg": "1 of 1 WARN 3",
+                "name": "LogTestResult",
+            },
+        },
+        event_history_metadata={},
+    )
+
+    events = list(event.to_default_asset_events(WARNED_TEST_MANIFEST, DagsterDbtTranslator()))
+
+    # No materialization: a test is not a refable node.
+    assert [e for e in events if isinstance(e, AssetMaterialization)] == []
+
+    evaluations = [e for e in events if isinstance(e, AssetCheckEvaluation)]
+    assert len(evaluations) == 1
+    assert evaluations[0].passed is False
+    assert evaluations[0].severity == AssetCheckSeverity.WARN


### PR DESCRIPTION
## Summary & Motivation

Fixes #33920.

dbt marks a node it deliberately did not rebuild with a terminal, non-error status:
`no-op` (added in dbt-core 1.10) or `reused` (added in dbt-core 1.12). Three call sites
in `dagster-dbt` compared the node status with `== "success"`, so every other status fell
through to the failure path — no materialization was emitted for the node, and the asset
silently went stale.

Worth being precise about the symptom, since the issue title says these are treated as
failures: dbt asset outputs are `Nothing`-typed, so Dagster emits an implicit `Nothing`
rather than raising, and **the run still reports success**. The asset just never
materializes. That is arguably worse than a loud failure — freshness checks and eager
automation conditions downstream never fire, which is the cascade the reporter and
@rehan243 (who hit this in production on 1.10) describe.

This introduces one shared constant in `compat.py`:

```python
SUCCESSFUL_NODE_STATUSES: frozenset[str] = frozenset({"success", "no-op", "reused", "warn"})
```

and uses it in all three places:

- `core/dbt_cli_event.py` — the dbt CLI / Fusion path
- `cloud_v2/run_handler.py` — the dbt Cloud v2 `run_results.json` path (the site linked in the issue)
- `cloud/utils.py` — the legacy dbt Cloud path, which is still exported from `dagster_dbt` and has the same bug

The statuses are spelled as string literals rather than `NodeStatus.NoOp` / `NodeStatus.Reused`
on purpose: `dagster-dbt` supports `dbt-core>=1.7,<1.12` and neither is a `NodeStatus` member
across that whole range. Both were also added to the fallback enum used when dbt-core is not
installed, so it mirrors dbt-core.

Refable materializations now also carry `status` metadata, so it is visible in the UI that
nothing was built. This mirrors what the test/check events already do. Note this adds a
metadata key to **every** dbt materialization, not just non-`success` ones — happy to scope it
to the non-`success` case instead if reviewers prefer.

### `warn` on a refable node

Added after review feedback that dbt Fusion can report model nodes as `warn` while treating them
as successful. Confirmed in [`dbt-fusion`'s `stats.rs`](https://github.com/dbt-labs/dbt-fusion/blob/main/crates/dbt-common/src/stats.rs):
Fusion has a dedicated `SucceededWithWarning` variant, documented as "Node built successfully in
the warehouse but produced warnings (e.g. duplicate columns)", which serializes to the wire string
`warn` and converts to a successful `NodeOutcome` alongside `Succeeded`. dagster-dbt was dropping
it, so such a model never materialized.

The subtlety worth reviewing closely: **`warn` means opposite things either side of the
resource-type gate** — a success for a refable node, but a warn-severity check failure for a test —
and dbt serializes both to the same string. Every site using this constant is already gated on
`REFABLE_NODE_TYPES` / `ASSET_RESOURCE_TYPES`, and the test path compares against `TestStatus`
separately, so the two cannot mix. That constraint is documented on the constant and pinned by
`test_warn_on_a_test_is_still_a_warn_severity_check`. dbt-core's `RunStatus` has no `warn` member,
so accepting it cannot mask a dbt-core failure.

The same source also confirms the `reused` half of this PR is reachable via Fusion today, not just
dbt-core 1.12: all four of Fusion's `ReusedNoChanges` / `ReusedStillFresh` /
`ReusedStillFreshNoChanges` / `ReusedCloned` variants serialize to `reused`.

### Deliberately out of scope

- **`partial success`** — surfacing it as something other than a clean success is a separate
  design question, per the discussion on the issue.
- **Test / check statuses** — `TestStatus` has no `no-op` or `reused` members, and widening the
  check path could mask real failures.
- **Fusion's `NoOp` status** — Fusion serializes `NodeStatus::NoOp` to `skipped`, not `no-op`, and
  serializes `SkippedUpstreamFailed` to `skipped` as well. A genuine no-op is therefore
  indistinguishable on the wire from a skip caused by an upstream failure, so accepting `skipped`
  here would mask real failures. That one needs a disambiguating signal from Fusion rather than a
  status-set change.

## Test Plan

New coverage in both directions:

- `dagster_dbt_tests/core/test_dbt_cli_event.py` (new file) — parametrized over
  `success` / `no-op` / `reused` (must materialize, with `status` metadata) and
  `error` / `fail` / `skipped` / `runtime error` (must not).
- `dagster_dbt_tests/cloud_v2/test_run_events.py` — the same two directions against
  `run_results.json`. The `no-op` / `reused` case also exercises an empty `timing` array,
  which `get_completed_at_timestamp` already falls back on.

All three parametrize over `success` / `no-op` / `reused` / `warn` in the positive direction.
Against `master`'s source these new tests fail with `assert 0 == 8`; with the fix they pass.

`test_warn_on_a_test_is_still_a_warn_severity_check` guards the resource-type gate described above.

`dagster_dbt_tests/cloud_v2/test_sensor.py` needed its exact-metadata-key assertion updated for
the new `status` key.

Wider runs locally: `dagster_dbt_tests/core` at 216 passed plus 34 asset-check tests; remaining
failures there need real Snowflake/BigQuery credentials. `dagster_dbt_tests/cloud` matches
`master` exactly, including 4 pre-existing `test_request_flake` failures. `ruff check` and
`ruff format --check` clean.

Also verified end to end in the Dagster UI with a local duckdb dbt project: before the fix the
model is absent from the run's materializations, after it materializes with a `status: no-op`
metadata row. Since dbt-core OSS never sets `no-op` or `reused` on a model — `NoOpRunner` covers
only exposures and saved queries, and `Reused` is set by dbt Fusion — that check injects the
status into the dbt event stream; everything downstream of that point is the real code path.

## Changelog

Fixed a bug where dbt nodes reporting the `no-op`, `reused`, or `warn` status were not
materialized, leaving the corresponding assets stale even though the run succeeded. This includes
models that dbt Fusion reports as `SucceededWithWarning`.
