### PR TITLE
[dagster-snowflake] Treat `no-op` and `reused` node statuses as successful

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/utils.py
@@ -13,6 +13,7 @@ from dagster import (
 from dagster._core.definitions.metadata import RawMetadataValue
 
 from dagster_dbt.cloud.types import DbtCloudOutput
+from dagster_dbt.compat import SUCCESSFUL_NODE_STATUSES
 from dagster_dbt.utils import ASSET_RESOURCE_TYPES, default_node_info_to_asset_key
 
 
@@ -110,7 +111,7 @@ def result_to_events(
 
     node_resource_type = _resource_type(unique_id)
 
-    if node_resource_type in ASSET_RESOURCE_TYPES and status == "success":
+    if node_resource_type in ASSET_RESOURCE_TYPES and status in SUCCESSFUL_NODE_STATUSES:
         if generate_asset_outputs:
             yield Output(
                 value=None,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
@@ -86,15 +86,29 @@ class DbtCloudJobRunHandler:
             return None
 
 
-def get_completed_at_timestamp(result: Mapping[str, Any]) -> float:
+def get_completed_at_timestamp(
+    result: Mapping[str, Any], fallback_timestamp: float | None = None
+) -> float:
     timing = result["timing"]
     if len(timing) == 0:
-        # as a fallback, use the current timestamp
-        return get_current_timestamp()
+        # Nodes that dbt did not actually build -- e.g. `no-op` and `reused` -- can have no
+        # timing entries. Fall back to a timestamp belonging to the run itself rather than to
+        # the current time: the polling sensor sorts an asset's events by this value, so a
+        # wall-clock fallback would make an older run look newer than a run that really did
+        # rebuild the node.
+        return fallback_timestamp if fallback_timestamp is not None else get_current_timestamp()
     # result["timing"] is a list of events in run_results.json
     # For successful models and passing tests,
     # the last item of that list includes the timing details of the execution.
     return parser.parse(result["timing"][-1]["completed_at"]).timestamp()
+
+
+def get_run_generated_at_timestamp(run_results: Mapping[str, Any]) -> float:
+    """When the run's artifacts were generated, used as the completion timestamp for nodes
+    that dbt reported without any timing entries.
+    """
+    generated_at = run_results.get("metadata", {}).get("generated_at")
+    return parser.parse(generated_at).timestamp() if generated_at else get_current_timestamp()
 
 
 @record
@@ -148,6 +162,7 @@ class DbtCloudJobRunResults:
         run = DbtCloudRun.from_run_details(run_details=client.get_run_details(run_id=self.run_id))
 
         invocation_id: str = self.run_results["metadata"]["invocation_id"]
+        generated_at_timestamp: float = get_run_generated_at_timestamp(self.run_results)
         for result in self.run_results["results"]:
             unique_id: str = result["unique_id"]
             dbt_resource_props: Mapping[str, Any] = manifest["nodes"].get(unique_id)
@@ -197,7 +212,9 @@ class DbtCloudJobRunResults:
                     **default_metadata,
                     "status": result_status,
                     COMPLETED_AT_TIMESTAMP_METADATA_KEY: MetadataValue.timestamp(
-                        get_completed_at_timestamp(result=result)
+                        get_completed_at_timestamp(
+                            result=result, fallback_timestamp=generated_at_timestamp
+                        )
                     ),
                 }
                 if context and has_asset_def:
@@ -217,7 +234,9 @@ class DbtCloudJobRunResults:
                     **default_metadata,
                     "status": result_status,
                     COMPLETED_AT_TIMESTAMP_METADATA_KEY: MetadataValue.timestamp(
-                        get_completed_at_timestamp(result=result)
+                        get_completed_at_timestamp(
+                            result=result, fallback_timestamp=generated_at_timestamp
+                        )
                     ),
                 }
                 failure_count = result.get("failures")

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud_v2/run_handler.py
@@ -20,7 +20,7 @@ from requests.exceptions import RequestException
 from dagster_dbt.asset_utils import build_dbt_specs, get_asset_check_key_for_test
 from dagster_dbt.cloud_v2.client import DbtCloudWorkspaceClient
 from dagster_dbt.cloud_v2.types import DbtCloudRun
-from dagster_dbt.compat import REFABLE_NODE_TYPES, NodeStatus, NodeType, TestStatus
+from dagster_dbt.compat import REFABLE_NODE_TYPES, SUCCESSFUL_NODE_STATUSES, NodeType, TestStatus
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
 
 COMPLETED_AT_TIMESTAMP_METADATA_KEY = "dagster_dbt/completed_at_timestamp"
@@ -189,12 +189,13 @@ class DbtCloudJobRunResults:
 
             if (
                 resource_type in REFABLE_NODE_TYPES
-                and result_status == NodeStatus.Success
+                and result_status in SUCCESSFUL_NODE_STATUSES
                 and not is_ephemeral
             ):
                 spec = asset_specs[0]
                 metadata = {
                     **default_metadata,
+                    "status": result_status,
                     COMPLETED_AT_TIMESTAMP_METADATA_KEY: MetadataValue.timestamp(
                         get_completed_at_timestamp(result=result)
                     ),

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/compat.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/compat.py
@@ -106,10 +106,21 @@ else:
             Skipped = NodeStatus.Skipped
 
 
-# The statuses a refable node (model, seed, snapshot) can end on without having failed. `no-op`
-# (dbt 1.10+) and `reused` (dbt 1.12+) are terminal, non-error statuses meaning dbt deliberately
-# did not rebuild the node, so downstream nodes are free to run. Neither is a member of
-# `NodeStatus` on every dbt version dagster-dbt supports, hence the string literals.
-SUCCESSFUL_NODE_STATUSES: frozenset[str] = frozenset({"success", "no-op", "reused"})
+# The statuses a refable node (model, seed, snapshot) can end on without having failed.
+#
+# Use this ONLY for refable nodes -- it is not valid for tests. `warn` is a success for a
+# refable node but a warn-severity failure for a test, and the two are indistinguishable on the
+# wire, so the test path must keep comparing against `TestStatus` instead.
+#
+# - `no-op` (dbt-core 1.10+) and `reused` (dbt-core 1.12+, and every `Reused*` variant in dbt
+#   Fusion) are terminal, non-error statuses meaning dbt deliberately did not rebuild the node.
+# - `warn` is what dbt Fusion serializes its `SucceededWithWarning` status to: the node built
+#   successfully but emitted a warning (e.g. duplicate columns). Fusion itself maps that status
+#   to a successful `NodeOutcome`, and dbt-core's `RunStatus` has no `warn` member at all, so
+#   accepting it here cannot mask a dbt-core failure.
+#
+# These are spelled as string literals because none of them is a `NodeStatus` member across the
+# whole `dbt-core>=1.7,<1.12` range that dagster-dbt supports.
+SUCCESSFUL_NODE_STATUSES: frozenset[str] = frozenset({"success", "no-op", "reused", "warn"})
 
 logging.getLogger().handlers = existing_root_logger_handlers

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/compat.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/compat.py
@@ -95,6 +95,8 @@ else:
             PartialSuccess = "partial success"
             Pass = "pass"
             RuntimeErr = "runtime error"
+            NoOp = "no-op"
+            Reused = "reused"
 
         class TestStatus(StrEnum):
             Pass = NodeStatus.Pass
@@ -103,5 +105,11 @@ else:
             Warn = NodeStatus.Warn
             Skipped = NodeStatus.Skipped
 
+
+# The statuses a refable node (model, seed, snapshot) can end on without having failed. `no-op`
+# (dbt 1.10+) and `reused` (dbt 1.12+) are terminal, non-error statuses meaning dbt deliberately
+# did not rebuild the node, so downstream nodes are free to run. Neither is a member of
+# `NodeStatus` on every dbt version dagster-dbt supports, hence the string literals.
+SUCCESSFUL_NODE_STATUSES: frozenset[str] = frozenset({"success", "no-op", "reused"})
 
 logging.getLogger().handlers = existing_root_logger_handlers

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
@@ -33,7 +33,13 @@ from dagster_dbt.asset_utils import (
     get_asset_check_key_for_test,
     get_checks_on_sources_upstream_of_selected_assets,
 )
-from dagster_dbt.compat import REFABLE_NODE_TYPES, NodeStatus, NodeType, TestStatus
+from dagster_dbt.compat import (
+    REFABLE_NODE_TYPES,
+    SUCCESSFUL_NODE_STATUSES,
+    NodeStatus,
+    NodeType,
+    TestStatus,
+)
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, validate_translator
 from dagster_dbt.dbt_manifest import DbtManifestParam, validate_manifest
 from dagster_dbt.dbt_project import DbtProject
@@ -272,7 +278,7 @@ class DbtCliEventMessage(ABC):
         return (
             resource_props["resource_type"] in REFABLE_NODE_TYPES
             and materialized_type != "ephemeral"
-            and self._get_node_status() == NodeStatus.Success
+            and self._get_node_status() in SUCCESSFUL_NODE_STATUSES
         )
 
     def _is_test_execution_event(self, manifest: Mapping[str, Any]) -> bool:
@@ -388,6 +394,7 @@ class DbtCliEventMessage(ABC):
         return {
             **self._get_default_metadata(manifest),
             **self._get_lineage_metadata(translator, manifest, target_path, project),
+            "status": self._get_node_status(),
         }
 
     def _to_model_events(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_utils.py
@@ -1,0 +1,45 @@
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from dagster import AssetMaterialization
+from dagster_dbt.cloud.utils import result_to_events
+
+SAMPLE_RUN_RESULTS = json.loads(
+    Path(__file__).parent.joinpath("sample_run_results.json").read_text()
+)
+
+
+def refable_result(status: str) -> dict[str, Any]:
+    result = copy.deepcopy(SAMPLE_RUN_RESULTS["results"][0])
+    result["status"] = status
+    if status != "success":
+        # dbt records no timings for a node it never built.
+        result["timing"] = []
+    return result
+
+
+def materializations_for(status: str) -> list[AssetMaterialization]:
+    return [
+        event
+        for event in result_to_events(refable_result(status))
+        if isinstance(event, AssetMaterialization)
+    ]
+
+
+@pytest.mark.parametrize("status", ["success", "no-op", "reused"])
+def test_non_error_statuses_materialize(status: str) -> None:
+    """`no-op` (dbt-core 1.10+) and `reused` (dbt-core 1.12+) are terminal, non-error statuses
+    meaning dbt did not rebuild the node, so the model should still be materialized.
+    """
+    materializations = materializations_for(status)
+
+    assert len(materializations) == 1
+    assert materializations[0].metadata["Status"].value == status
+
+
+@pytest.mark.parametrize("status", ["error", "fail", "skipped", "runtime error"])
+def test_error_statuses_do_not_materialize(status: str) -> None:
+    assert materializations_for(status) == []

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_utils.py
@@ -29,7 +29,7 @@ def materializations_for(status: str) -> list[AssetMaterialization]:
     ]
 
 
-@pytest.mark.parametrize("status", ["success", "no-op", "reused"])
+@pytest.mark.parametrize("status", ["success", "no-op", "reused", "warn"])
 def test_non_error_statuses_materialize(status: str) -> None:
     """`no-op` (dbt-core 1.10+) and `reused` (dbt-core 1.12+) are terminal, non-error statuses
     meaning dbt did not rebuild the node, so the model should still be materialized.

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_run_events.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_run_events.py
@@ -1,5 +1,6 @@
 import copy
 
+import pytest
 import responses
 from dagster import AssetCheckEvaluation, AssetMaterialization
 from dagster_dbt.cloud_v2.resources import DbtCloudWorkspace
@@ -67,3 +68,60 @@ def test_default_asset_events_from_run_results_missing_failures_key(
     # Without a `failures` count, we should not attach failed row count metadata.
     for check_eval in asset_check_evaluations:
         assert "dagster_dbt/failed_row_count" not in check_eval.metadata
+
+
+@pytest.mark.parametrize("status", ["no-op", "reused"])
+def test_default_asset_events_from_run_results_non_error_statuses(
+    status: str,
+    workspace: DbtCloudWorkspace,
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+):
+    """`no-op` and `reused` are terminal, non-error dbt statuses meaning the node was not rebuilt.
+    The models they are reported for should still materialize rather than be dropped as failures.
+    """
+    run_results_json = copy.deepcopy(dict(get_sample_run_results_json()))
+    for result in run_results_json["results"]:
+        if result["status"] == "success":
+            result["status"] = status
+            # dbt does not record timings for a node it never built.
+            result["timing"] = []
+
+    run_results = DbtCloudJobRunResults.from_run_results_json(run_results_json=run_results_json)
+
+    events = list(
+        run_results.to_default_asset_events(
+            client=workspace.get_client(),
+            manifest=workspace.get_or_fetch_workspace_data().manifest,
+        )
+    )
+
+    asset_materializations = [event for event in events if isinstance(event, AssetMaterialization)]
+    asset_check_evaluations = [event for event in events if isinstance(event, AssetCheckEvaluation)]
+
+    assert len(asset_materializations) == 8
+    assert len(asset_check_evaluations) == 20
+
+    # The status is surfaced as metadata so that it is visible that nothing was built.
+    for materialization in asset_materializations:
+        assert materialization.metadata["status"].value == status
+
+
+def test_default_asset_events_from_run_results_error_status(
+    workspace: DbtCloudWorkspace, fetch_workspace_data_api_mocks: responses.RequestsMock
+):
+    """Models that errored are still not materialized."""
+    run_results_json = copy.deepcopy(dict(get_sample_run_results_json()))
+    for result in run_results_json["results"]:
+        if result["status"] == "success":
+            result["status"] = "error"
+
+    run_results = DbtCloudJobRunResults.from_run_results_json(run_results_json=run_results_json)
+
+    events = list(
+        run_results.to_default_asset_events(
+            client=workspace.get_client(),
+            manifest=workspace.get_or_fetch_workspace_data().manifest,
+        )
+    )
+
+    assert [event for event in events if isinstance(event, AssetMaterialization)] == []

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_run_events.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_run_events.py
@@ -74,7 +74,7 @@ def test_default_asset_events_from_run_results_missing_failures_key(
         assert "dagster_dbt/failed_row_count" not in check_eval.metadata
 
 
-@pytest.mark.parametrize("status", ["no-op", "reused"])
+@pytest.mark.parametrize("status", ["no-op", "reused", "warn"])
 def test_default_asset_events_from_run_results_non_error_statuses(
     status: str,
     workspace: DbtCloudWorkspace,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_run_events.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_run_events.py
@@ -4,7 +4,11 @@ import pytest
 import responses
 from dagster import AssetCheckEvaluation, AssetMaterialization
 from dagster_dbt.cloud_v2.resources import DbtCloudWorkspace
-from dagster_dbt.cloud_v2.run_handler import DbtCloudJobRunResults
+from dagster_dbt.cloud_v2.run_handler import (
+    COMPLETED_AT_TIMESTAMP_METADATA_KEY,
+    DbtCloudJobRunResults,
+)
+from dateutil import parser
 
 from dagster_dbt_tests.cloud_v2.conftest import TEST_RUN_URL, get_sample_run_results_json
 
@@ -125,3 +129,37 @@ def test_default_asset_events_from_run_results_error_status(
     )
 
     assert [event for event in events if isinstance(event, AssetMaterialization)] == []
+
+
+@pytest.mark.parametrize("status", ["no-op", "reused"])
+def test_timing_less_results_use_the_run_generated_at_timestamp(
+    status: str,
+    workspace: DbtCloudWorkspace,
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+):
+    """A node dbt never built can have no timing entries. The completion timestamp must come
+    from the run's own `generated_at` rather than the current time -- the polling sensor sorts
+    an asset's events by it, so a wall-clock fallback would make an older run that skipped the
+    node sort ahead of a newer run that actually rebuilt it.
+    """
+    run_results_json = copy.deepcopy(dict(get_sample_run_results_json()))
+    for result in run_results_json["results"]:
+        if result["status"] == "success":
+            result["status"] = status
+            result["timing"] = []
+
+    expected = parser.parse(run_results_json["metadata"]["generated_at"]).timestamp()
+
+    run_results = DbtCloudJobRunResults.from_run_results_json(run_results_json=run_results_json)
+
+    events = list(
+        run_results.to_default_asset_events(
+            client=workspace.get_client(),
+            manifest=workspace.get_or_fetch_workspace_data().manifest,
+        )
+    )
+
+    asset_materializations = [event for event in events if isinstance(event, AssetMaterialization)]
+    assert len(asset_materializations) == 8
+    for materialization in asset_materializations:
+        assert materialization.metadata[COMPLETED_AT_TIMESTAMP_METADATA_KEY].value == expected

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_sensor.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud_v2/test_sensor.py
@@ -49,6 +49,7 @@ def test_asset_materializations(
         "invocation_id",
         "run_url",
         "execution_duration",
+        "status",
     }
     assert set(first_asset_mat.metadata.keys()) == expected_metadata_keys
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_dbt_cli_event.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_dbt_cli_event.py
@@ -1,0 +1,87 @@
+import pytest
+from dagster import AssetMaterialization
+from dagster_dbt.core.dbt_cli_event import DbtCoreCliEventMessage
+from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
+
+MANIFEST = {
+    "metadata": {
+        "invocation_id": "c630c6bf-633e-4612-8e46-2f170224066c",
+        "generated_at": "2025-03-10T12:54:41.369662Z",
+    },
+    "nodes": {
+        "model.pytest_dwh.public__orders": {
+            "unique_id": "model.pytest_dwh.public__orders",
+            "name": "public__orders",
+            "resource_type": "model",
+            "materialized": "incremental",
+            "database": "dev",
+            "schema": "public",
+            "alias": "order_history",
+            "path": "mart/public__orders.sql",
+            "config": {"schema": "public"},
+            "description": "",
+        }
+    },
+}
+
+
+def build_log_model_result(node_status: str) -> DbtCoreCliEventMessage:
+    return DbtCoreCliEventMessage(
+        raw_event={
+            "data": {
+                "description": "sql incremental model public.orders",
+                "execution_time": 0.1,
+                "index": 1,
+                "node_info": {
+                    "materialized": "incremental",
+                    "node_finished_at": "2025-03-10T12:53:48.818126",
+                    "node_name": "public__orders",
+                    "node_path": "mart/public__orders.sql",
+                    "node_started_at": "2025-03-10T12:53:36.820592",
+                    "node_status": node_status,
+                    "resource_type": "model",
+                    "unique_id": "model.pytest_dwh.public__orders",
+                },
+                "status": node_status.upper(),
+                "total": 1,
+            },
+            "info": {
+                "invocation_id": "c630c6bf-633e-4612-8e46-2f170224066c",
+                "level": "info",
+                "msg": "1 of 1 OK",
+                "name": "LogModelResult",
+            },
+        },
+        event_history_metadata={},
+    )
+
+
+@pytest.mark.parametrize("node_status", ["success", "no-op", "reused"])
+def test_non_error_node_statuses_materialize(node_status: str) -> None:
+    """`no-op` (dbt 1.10+) and `reused` (dbt 1.12+) are terminal, non-error statuses meaning dbt
+    did not rebuild the node. They must materialize the asset rather than be treated as failures,
+    otherwise the missing materialization cascades to downstream assets.
+    """
+    events = list(
+        build_log_model_result(node_status).to_default_asset_events(
+            MANIFEST, DagsterDbtTranslator()
+        )
+    )
+
+    assert len(events) == 1
+    materialization = events[0]
+    assert isinstance(materialization, AssetMaterialization)
+    assert materialization.asset_key.path == ["public", "public__orders"]
+    # The status is surfaced as metadata so that it is visible that nothing was built.
+    assert materialization.metadata["status"].value == node_status
+
+
+@pytest.mark.parametrize("node_status", ["error", "fail", "skipped", "runtime error"])
+def test_error_node_statuses_do_not_materialize(node_status: str) -> None:
+    events = list(
+        build_log_model_result(node_status).to_default_asset_events(
+            MANIFEST, DagsterDbtTranslator()
+        )
+    )
+
+    assert events == []

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_dbt_cli_event.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_dbt_cli_event.py
@@ -1,5 +1,5 @@
 import pytest
-from dagster import AssetMaterialization
+from dagster import AssetCheckEvaluation, AssetCheckSeverity, AssetMaterialization
 from dagster_dbt.core.dbt_cli_event import DbtCoreCliEventMessage
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
 
@@ -56,11 +56,14 @@ def build_log_model_result(node_status: str) -> DbtCoreCliEventMessage:
     )
 
 
-@pytest.mark.parametrize("node_status", ["success", "no-op", "reused"])
+@pytest.mark.parametrize("node_status", ["success", "no-op", "reused", "warn"])
 def test_non_error_node_statuses_materialize(node_status: str) -> None:
-    """`no-op` (dbt 1.10+) and `reused` (dbt 1.12+) are terminal, non-error statuses meaning dbt
-    did not rebuild the node. They must materialize the asset rather than be treated as failures,
-    otherwise the missing materialization cascades to downstream assets.
+    """Statuses a refable node can end on without having failed must materialize the asset,
+    rather than be silently dropped.
+
+    `no-op` (dbt-core 1.10+) and `reused` (dbt-core 1.12+, and dbt Fusion's `Reused*` variants)
+    mean dbt deliberately did not rebuild the node. `warn` is what dbt Fusion serializes
+    `SucceededWithWarning` to -- the node did build, it just emitted a warning.
     """
     events = list(
         build_log_model_result(node_status).to_default_asset_events(
@@ -85,3 +88,65 @@ def test_error_node_statuses_do_not_materialize(node_status: str) -> None:
     )
 
     assert events == []
+
+
+WARNED_TEST_MANIFEST = {
+    "metadata": MANIFEST["metadata"],
+    "nodes": {
+        **MANIFEST["nodes"],
+        "test.pytest_dwh.unique_orders": {
+            "unique_id": "test.pytest_dwh.unique_orders",
+            "name": "unique_orders",
+            "resource_type": "test",
+            "materialized": "test",
+            "database": "dev",
+            "schema": "public",
+            "alias": "unique_orders",
+            "path": "unique_orders.sql",
+            "config": {"schema": "public"},
+            "description": "",
+            "depends_on": {"nodes": ["model.pytest_dwh.public__orders"]},
+            "attached_node": "model.pytest_dwh.public__orders",
+        },
+    },
+}
+
+
+def test_warn_on_a_test_is_still_a_warn_severity_check() -> None:
+    """`warn` means opposite things either side of the resource-type gate: a success for a
+    refable node, but a warn-severity check failure for a test. dbt serializes both to the same
+    string, so accepting `warn` for models must not leak into the test path.
+    """
+    event = DbtCoreCliEventMessage(
+        raw_event={
+            "data": {
+                "node_info": {
+                    "node_status": "warn",
+                    "node_name": "unique_orders",
+                    "resource_type": "test",
+                    "unique_id": "test.pytest_dwh.unique_orders",
+                    "node_started_at": "2025-03-10T12:53:36.820592",
+                    "node_finished_at": "2025-03-10T12:53:48.818126",
+                },
+                "status": "WARN",
+                "num_failures": 3,
+            },
+            "info": {
+                "invocation_id": "c630c6bf-633e-4612-8e46-2f170224066c",
+                "level": "warn",
+                "msg": "1 of 1 WARN 3",
+                "name": "LogTestResult",
+            },
+        },
+        event_history_metadata={},
+    )
+
+    events = list(event.to_default_asset_events(WARNED_TEST_MANIFEST, DagsterDbtTranslator()))
+
+    # No materialization: a test is not a refable node.
+    assert [e for e in events if isinstance(e, AssetMaterialization)] == []
+
+    evaluations = [e for e in events if isinstance(e, AssetCheckEvaluation)]
+    assert len(evaluations) == 1
+    assert evaluations[0].passed is False
+    assert evaluations[0].severity == AssetCheckSeverity.WARN

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/components/dbt_project/component.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/components/dbt_project/component.py
@@ -70,8 +70,9 @@ from dagster_dbt.asset_utils import (
 from dagster_dbt.cloud_v2.run_handler import (
     COMPLETED_AT_TIMESTAMP_METADATA_KEY,
     get_completed_at_timestamp,
+    get_run_generated_at_timestamp,
 )
-from dagster_dbt.compat import REFABLE_NODE_TYPES, NodeStatus, NodeType, TestStatus
+from dagster_dbt.compat import REFABLE_NODE_TYPES, SUCCESSFUL_NODE_STATUSES, NodeType, TestStatus
 from dagster_dbt.components.dbt_component_utils import (
     DagsterDbtComponentTranslatorSettings,
     _set_resolution_context,
@@ -920,6 +921,7 @@ class SnowflakeDbtProjectComponent(StateBackedComponent, dg.Resolvable):
         op_mode = context is not None
         translator = validate_translator(self.translator)
         invocation_id = run_results.get("metadata", {}).get("invocation_id")
+        generated_at_timestamp = get_run_generated_at_timestamp(run_results)
 
         for result in run_results.get("results", []):
             unique_id = result["unique_id"]
@@ -938,7 +940,7 @@ class SnowflakeDbtProjectComponent(StateBackedComponent, dg.Resolvable):
 
             if (
                 resource_type in REFABLE_NODE_TYPES
-                and status == NodeStatus.Success
+                and status in SUCCESSFUL_NODE_STATUSES
                 and not is_ephemeral
             ):
                 asset_key = translator.get_asset_spec(manifest, unique_id, None).key
@@ -949,8 +951,9 @@ class SnowflakeDbtProjectComponent(StateBackedComponent, dg.Resolvable):
                     continue
                 metadata = {
                     **default_metadata,
+                    "status": status,
                     COMPLETED_AT_TIMESTAMP_METADATA_KEY: dg.MetadataValue.timestamp(
-                        get_completed_at_timestamp(result)
+                        get_completed_at_timestamp(result, generated_at_timestamp)
                     ),
                 }
                 # Extra metadata only applies during op execution (the sensor skips it).
@@ -991,7 +994,7 @@ class SnowflakeDbtProjectComponent(StateBackedComponent, dg.Resolvable):
                     **default_metadata,
                     "status": status,
                     COMPLETED_AT_TIMESTAMP_METADATA_KEY: dg.MetadataValue.timestamp(
-                        get_completed_at_timestamp(result)
+                        get_completed_at_timestamp(result, generated_at_timestamp)
                     ),
                 }
                 if result.get("failures") is not None:
@@ -1055,7 +1058,7 @@ class SnowflakeDbtProjectComponent(StateBackedComponent, dg.Resolvable):
             props = nodes.get(unique_id)
             if not props or props.get("resource_type") not in REFABLE_NODE_TYPES:
                 continue
-            if result.get("status") != NodeStatus.Success:
+            if result.get("status") not in SUCCESSFUL_NODE_STATUSES:
                 continue
             if props.get("config", {}).get("materialized") == "ephemeral":
                 continue

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_dbt_project_component.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_dbt_project_component.py
@@ -8,6 +8,7 @@ at parity with dbt core / dbt Cloud -- without standing up a real dbt project or
 connection.
 """
 
+import copy
 import datetime
 import json
 import os
@@ -18,6 +19,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 from unittest import mock
 
+import dateutil.parser
 import pytest
 from dagster import (
     AssetCheckKey,
@@ -34,6 +36,7 @@ from dagster_shared.serdes.objects.models.defs_state_info import DefsStateManage
 pytest.importorskip("dagster_dbt")
 
 import dagster_snowflake.components.dbt_project.component as comp_mod
+from dagster_dbt.cloud_v2.run_handler import COMPLETED_AT_TIMESTAMP_METADATA_KEY
 from dagster_snowflake.components.dbt_project.component import (
     _QUERY_TAG_MARKER,
     SnowflakeDbtProjectComponent,
@@ -320,6 +323,54 @@ _RUN_RESULTS = {
         },
     ],
 }
+
+
+@pytest.mark.parametrize("status", ["success", "no-op", "reused"])
+def test_run_results_to_events_non_error_statuses_materialize(status: str) -> None:
+    """`no-op` (dbt-core 1.10+) and `reused` (dbt-core 1.12+) are terminal, non-error statuses
+    meaning dbt did not rebuild the node, so the model must still be materialized. Keeps this
+    component at parity with `DbtCloudJobRunResults.to_default_asset_events`.
+    """
+    run_results = copy.deepcopy(_RUN_RESULTS)
+    run_results["metadata"]["generated_at"] = "2024-01-01T00:00:09Z"
+    # Only the model result matters here; the test-node branch needs its own check-key wiring.
+    run_results["results"] = [run_results["results"][0]]
+    run_results["results"][0]["status"] = status
+    if status != "success":
+        # dbt records no timings for a node it never built.
+        run_results["results"][0]["timing"] = []
+
+    fake_translator = mock.MagicMock()
+    fake_translator.get_asset_spec.return_value = SimpleNamespace(key=AssetKey(["customers"]))
+
+    component = _make_component()
+    with mock.patch.object(comp_mod, "validate_translator", return_value=fake_translator):
+        events = list(component._run_results_to_events(run_results, _MANIFEST))  # noqa: SLF001
+
+    mats = [e for e in events if isinstance(e, AssetMaterialization)]
+    assert len(mats) == 1
+    assert mats[0].metadata["status"].value == status
+    # A timing-less result must not fall back to wall-clock time: the metadata timestamp is
+    # persisted and compared across runs, so it has to come from the run itself.
+    expected = dateutil.parser.parse(run_results["metadata"]["generated_at"]).timestamp()
+    if status != "success":
+        assert mats[0].metadata[COMPLETED_AT_TIMESTAMP_METADATA_KEY].value == expected
+
+
+@pytest.mark.parametrize("status", ["error", "fail", "skipped", "runtime error"])
+def test_run_results_to_events_error_statuses_do_not_materialize(status: str) -> None:
+    run_results = copy.deepcopy(_RUN_RESULTS)
+    run_results["results"] = [run_results["results"][0]]
+    run_results["results"][0]["status"] = status
+
+    fake_translator = mock.MagicMock()
+    fake_translator.get_asset_spec.return_value = SimpleNamespace(key=AssetKey(["customers"]))
+
+    component = _make_component()
+    with mock.patch.object(comp_mod, "validate_translator", return_value=fake_translator):
+        events = list(component._run_results_to_events(run_results, _MANIFEST))  # noqa: SLF001
+
+    assert [e for e in events if isinstance(e, AssetMaterialization)] == []
 
 
 def test_execute_submits_async_and_sets_query_tag():


### PR DESCRIPTION
## Summary & Motivation

> [!IMPORTANT]
> **Stacked on #34195.** This needs `SUCCESSFUL_NODE_STATUSES` and
> `get_run_generated_at_timestamp`, both added there, so the diff below includes that PR's
> two commits until it lands. Review only `55e45cb997`; merge after #34195.

`SnowflakeDbtProjectComponent._run_results_to_events` documents itself as mirroring
`DbtCloudJobRunResults.to_default_asset_events`, and `test_execute_emits_run_results_metadata_at_parity`
asserts that parity holds. It carried the same two bugs that #34195 fixes for `dagster-dbt`, so
fixing only that side would leave the two implementations silently divergent.

**1. `no-op` and `reused` were treated as failures.** Two sites compared the status with
`== NodeStatus.Success`:

- `_run_results_to_events` (`component.py:940`) — no materialization was emitted for the node
- `_collect_relations` (`component.py:1058`) — the node was excluded from row-count and column-metadata prefetch

Both are terminal, non-error statuses meaning dbt deliberately did not rebuild the node. Worth
being precise about the symptom: because these asset outputs are `Nothing`-typed, **the run still
reports success** — the asset just never materializes, so freshness checks and eager automation
conditions downstream never fire.

**2. Timing-less results fell back to wall-clock time.** A node dbt never built can have an empty
`timing` array, and `get_completed_at_timestamp` then returned the current time. That value is
persisted as `dagster_dbt/completed_at_timestamp` and compared across runs, so it now comes from
the run's own `metadata.generated_at` instead. The blast radius is smaller here than in dbt Cloud
— this component's observation sensor emits events in `QUERY_HISTORY` order rather than re-sorting
by the metadata timestamp — but the recorded value was still wrong.

Refable materializations also now carry the same `status` metadata as the dbt Cloud path, which is
what keeps the parity test meaningful.

## Test Plan

Added to `dagster_snowflake_tests/test_dbt_project_component.py`, mirroring the regression tests
in #34195 for the other three paths:

- `test_run_results_to_events_non_error_statuses_materialize` — parametrized over
  `success` / `no-op` / `reused`; asserts the model materializes, carries `status` metadata, and
  that a timing-less result takes its timestamp from `metadata.generated_at` rather than the wall clock.
- `test_run_results_to_events_error_statuses_do_not_materialize` — parametrized over
  `error` / `fail` / `skipped` / `runtime error`; asserts nothing materializes.

Verified the tests actually catch the bug: with the component reverted to `master` and the new
tests in place, the three `non_error_statuses_materialize` cases fail; with the fix, the full file
passes at **43 passed**. `ruff check` and `ruff format --check` clean.

## Changelog

Fixed a bug where the Snowflake dbt project component did not materialize assets for dbt nodes
reporting the `no-op` or `reused` status, leaving them stale even though the run succeeded.
