### PR TITLE
fix(dagster-wandb): use public W&B API

### DIFF
--- a/python_modules/libraries/dagster-wandb/dagster_wandb/resources.py
+++ b/python_modules/libraries/dagster-wandb/dagster_wandb/resources.py
@@ -3,7 +3,6 @@ from typing import Any
 import wandb
 from dagster import Field, InitResourceContext, String, StringSource, resource
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
-from wandb.sdk.internal.internal_api import Api
 
 WANDB_CLOUD_HOST: str = "https://api.wandb.ai"
 
@@ -60,11 +59,5 @@ def wandb_resource(context: InitResourceContext) -> dict[str, Any]:
         host=host,
         anonymous="never",
     )
-    client_settings = wandb.Settings(
-        api_key=api_key,
-        base_url=host,
-        anonymous="never",
-        launch=True,
-    )
-    api = Api(default_settings=client_settings, load_settings=False)
+    api = wandb.Api(overrides={"base_url": host}, api_key=api_key)
     return {"sdk": wandb, "api": api, "host": host}

--- a/python_modules/libraries/dagster-wandb/dagster_wandb_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-wandb/dagster_wandb_tests/test_io_manager.py
@@ -176,6 +176,12 @@ def init_mock():
         yield mock
 
 
+@pytest.fixture(autouse=True)
+def api_mock():
+    with patch("wandb.Api") as mock:
+        yield mock
+
+
 def test_wandb_artifacts_io_manager_handle_output_for_op_with_simple_output(
     init_mock, login_mock, run_mock, artifact_mock, log_artifact_mock, pickle_artifact_content_mock
 ):

--- a/python_modules/libraries/dagster-wandb/dagster_wandb_tests/test_resources.py
+++ b/python_modules/libraries/dagster-wandb/dagster_wandb_tests/test_resources.py
@@ -7,45 +7,25 @@ API_KEY = "api_key"
 CUSTOM_HOST = "https://qa.platform.ai"
 
 
-@patch("dagster_wandb.resources.Api")
 @patch("dagster_wandb.resources.wandb")
-def test_wandb_resource(wandb, api):
+def test_wandb_resource(wandb):
     init_context = build_init_resource_context(config={"api_key": API_KEY})
     assert wandb_resource(init_context) == {
         "sdk": wandb,
-        "api": api.return_value,
+        "api": wandb.Api.return_value,
         "host": WANDB_CLOUD_HOST,
     }
     wandb.login.assert_called_with(key=API_KEY, host=WANDB_CLOUD_HOST, anonymous="never")
-    wandb.Settings.assert_called_with(
-        api_key=API_KEY,
-        base_url=WANDB_CLOUD_HOST,
-        anonymous="never",
-        launch=True,
-    )
-    api.assert_called_with(
-        default_settings=wandb.Settings.return_value,
-        load_settings=False,
-    )
+    wandb.Api.assert_called_with(overrides={"base_url": WANDB_CLOUD_HOST}, api_key=API_KEY)
 
 
-@patch("dagster_wandb.resources.Api")
 @patch("dagster_wandb.resources.wandb")
-def test_wandb_resource_custom_host(wandb, api):
+def test_wandb_resource_custom_host(wandb):
     init_context = build_init_resource_context(config={"api_key": API_KEY, "host": CUSTOM_HOST})
     assert wandb_resource(init_context) == {
         "sdk": wandb,
-        "api": api.return_value,
+        "api": wandb.Api.return_value,
         "host": CUSTOM_HOST,
     }
     wandb.login.assert_called_with(key=API_KEY, host=CUSTOM_HOST, anonymous="never")
-    wandb.Settings.assert_called_with(
-        api_key=API_KEY,
-        base_url=CUSTOM_HOST,
-        anonymous="never",
-        launch=True,
-    )
-    api.assert_called_with(
-        default_settings=wandb.Settings.return_value,
-        load_settings=False,
-    )
+    wandb.Api.assert_called_with(overrides={"base_url": CUSTOM_HOST}, api_key=API_KEY)


### PR DESCRIPTION
## Summary & Motivation

`dagster_wandb` imported W&B's internal API module, which was removed in wandb 0.30.0. Use the supported `wandb.Api` interface instead, while keeping the configured host and API key.

Fixes https://github.com/dagster-io/dagster/issues/34198

## Test Plan

- `UV_CACHE_DIR=$PWD/.uv-cache TMPDIR=$PWD/.uv-tmp uv run --project . --group test --with wandb==0.30.0 pytest -vv ./dagster_wandb_tests` (43 passed)
- `UV_CACHE_DIR=$PWD/.uv-cache TMPDIR=$PWD/.uv-tmp uv run --project . --group test --with wandb==0.30.0 ruff check dagster_wandb dagster_wandb_tests` (all checks passed)
- `UV_CACHE_DIR=$PWD/.uv-cache TMPDIR=$PWD/.uv-tmp uv run --project . --group test --with wandb==0.30.0 ruff format --check dagster_wandb dagster_wandb_tests` (16 files already formatted)
- `UV_CACHE_DIR=$PWD/.uv-cache TMPDIR=$PWD/.uv-tmp uv run --project python_modules/libraries/dagster-wandb --with wandb==0.30.0 python -c "import dagster_wandb"` (import succeeds)
- The full repository test suite was not run.